### PR TITLE
Add UEL generator target — user element driven by any library model

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,37 @@ my_material/
     run.sh            ABAQUS submission script
 ```
 
+### User element (UEL) target
+
+Any material config can additionally be emitted as a **user element**: an
+8-node brick (U3) with full or reduced integration and the F-bar method of
+de Souza Neto (1996) against volumetric locking, with the material law driven
+through the same constitutive core as the UMAT (`material_uel` in
+`mod_material`). The UEL receives the bare spatial tangent plus the geometric
+term `a_ijkl = c_ijkl + δ_ik σ_jl` (the push-forward of ∂P/∂F that a
+displacement UEL's `Kuu = ∫ Gᵀ A G dv` assembly requires — *not* the
+Jaumann-corrected UMAT modulus), so Newton convergence is consistent.
+
+```bash
+uv run umat-generate --example neo_hooke --uel
+cd neo_hooke
+make run_uel                # standalone single-element driver, no ABAQUS
+cd abaqus && ./run_uel.sh   # ABAQUS UEL test (dummy mesh + UVARM for SDVs)
+```
+
+Configs may instead carry an `"element"` block:
+
+```json
+"element": {"nint": 8, "fbar": true, "num_elem": 1, "elem_offset": 1000}
+```
+
+`num_elem` must equal the number of UEL elements in the mesh and
+`elem_offset` the dummy-mesh element-number offset (both baked into
+`uel.f90` at generation). In the input deck, `*User Element` needs
+`Variables = nint × NSTATEV` and `Unsymm`; the generated `abaqus/uel_cube.inp`
+shows the full pattern. Element sources live in `src/element/`
+(ported from the standalone UEL-ABAQUS repository, which this supersedes).
+
 ### Running the standalone test
 
 ```bash

--- a/generate.py
+++ b/generate.py
@@ -32,6 +32,23 @@ SOURCE_FILES = [
     "uexternaldb.f90",
 ]
 
+# Element-layer sources appended after SOURCE_FILES when emitting uel.f90
+UEL_SOURCE_FILES = [
+    "element/mod_uel_config.f90",
+    "element/mod_uel_shape.f90",
+    "element/mod_uel_element.f90",
+    "element/uel_entry.f90",
+]
+
+# Defaults for the optional "element" config block (UEL emission)
+DEFAULT_ELEMENT = {
+    "type": "u3d8",      # 8-node brick (only type currently)
+    "nint": 8,           # volume integration points (1 or 8)
+    "fbar": True,        # F-bar locking treatment (active on the 8-pt brick)
+    "num_elem": 1,       # UEL elements in the real mesh (sizes globalSdv)
+    "elem_offset": 1000, # dummy-mesh element-number offset (must match deck)
+}
+
 # --- Example configurations ---------------------------------------------------
 
 EXAMPLES = {
@@ -353,6 +370,301 @@ def generate_aba_param(outdir):
     (outdir / "aba_param.inc").write_text(src.read_text())
 
 
+# --- UEL emission ---------------------------------------------------------
+
+def element_cfg(cfg):
+    """Merged element block (or None if UEL emission is not requested)."""
+    if "element" not in cfg:
+        return None
+    elem = dict(DEFAULT_ELEMENT)
+    elem.update(cfg["element"] or {})
+    return elem
+
+
+def subst_uel_config(text, elem):
+    """Rewrite the parameter values in mod_uel_config.f90 from the element block."""
+    import re
+    text = re.sub(r"(numElem\s*=\s*)\d+", rf"\g<1>{elem['num_elem']}", text)
+    text = re.sub(r"(ElemOffset\s*=\s*)\d+", rf"\g<1>{elem['elem_offset']}", text)
+    fbar = ".true." if elem["fbar"] else ".false."
+    text = re.sub(r"(use_fbar\s*=\s*)\.\w+\.", rf"\g<1>{fbar}", text)
+    text = re.sub(r"(nIntPt\s*=\s*)\d+", rf"\g<1>{elem['nint']}", text)
+    return text
+
+
+def uel_source(elem):
+    """Concatenated uel.f90 text: material modules + element layer."""
+    parts = []
+    for src in SOURCE_FILES + UEL_SOURCE_FILES:
+        text = (SRC_DIR / src).read_text()
+        if src.endswith("mod_uel_config.f90"):
+            text = subst_uel_config(text, elem)
+        parts.append(f"! {'='*72}\n! SOURCE: {src}\n! {'='*72}\n" + text)
+    return ("! Auto-generated UEL (user element + material library) — do not edit.\n"
+            "! Regenerate with: python generate.py <config.json>\n\n"
+            + "\n\n".join(parts) + "\n")
+
+
+def generate_uel_f90(outdir, cfg, elem):
+    (outdir / "uel.f90").write_text(uel_source(elem))
+
+
+# Unit-cube nodes in the element's local ordering (sketch in mod_uel_element):
+# bottom face z=0: 1(0,0,0) 2(1,0,0) 3(1,1,0) 4(0,1,0); top face z=1: 5..8
+UEL_CUBE_COORDS = [
+    (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0),
+    (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 1.0), (0.0, 1.0, 1.0),
+]
+
+
+def generate_uel_test_driver(outdir, cfg, elem):
+    """Standalone single-element driver: ramps the unit cube through affine
+    deformation histories (same load cases as test_umat) and records the
+    internal force on the x+ face (nodes 2,3,6,7)."""
+    props = build_props(cfg)
+    nprops = len(props)
+    nstatev = compute_nstatev(cfg)
+    nint = elem["nint"]
+    test = cfg.get("test", {})
+    stretch_max = test.get("stretch_max", 1.5)
+    gamma_max = test.get("gamma_max", 0.6)
+    nsteps = test.get("nsteps", 400)
+    dtime = test.get("dtime", 0.01)
+
+    coords_lines = "\n".join(
+        f"  coords(1,{i+1}) = {x:.1f}d0; coords(2,{i+1}) = {y:.1f}d0; coords(3,{i+1}) = {z:.1f}d0"
+        for i, (x, y, z) in enumerate(UEL_CUBE_COORDS))
+
+    code = f"""\
+! Auto-generated UEL test driver for material: {cfg["name"]}
+! Drives one U3D8 element through affine deformation ramps (no ABAQUS).
+! Output columns: step time, control parameter, x+ face force (fx, fy, fz).
+program test_uel
+  implicit none
+
+  integer, parameter :: nnode = 8, ndofel = 24, mlvarx = 24, nrhs = 1
+  integer, parameter :: nprops = {nprops}, nsdv = {nstatev}, nintp = {nint}
+  integer, parameter :: nsvars = nintp*nsdv, njprop = 2
+  integer, parameter :: mcrd = 3, jtype = 3, jelem = 1
+  integer, parameter :: ndload = 0, mdload = 1, npredf = 1
+
+  double precision :: rhs(mlvarx,1), amatrx(ndofel,ndofel), svars(nsvars)
+  double precision :: energy(8), props(nprops), coords(mcrd,nnode)
+  double precision :: u(ndofel), du(mlvarx,1), v(ndofel), a(ndofel)
+  double precision :: time(2), dtime, params(1)
+  double precision :: adlmag(mdload,1), ddlmag(mdload,1)
+  double precision :: predef(2,npredf,nnode), pnewdt, period
+  integer :: jdltyp(mdload,1), lflags(4), jprops(njprop)
+
+  double precision :: Ftar(3,3)
+  double precision :: stretch_max, gamma_max
+  integer :: nsteps
+  double precision, parameter :: zero = 0.0d0, one = 1.0d0
+
+  ! --- Element/material setup ---
+{fmt_props_fortran(props)}
+  jprops(1) = nsdv   ! local SDVs per integration point
+  jprops(2) = nsdv   ! global SDVs per integration point (UVARM)
+  lflags = 0
+  lflags(1) = 1      ! static general step
+  lflags(2) = 1      ! nlgeom=yes
+  dtime = {dtime}d0
+  nsteps = {nsteps}
+  stretch_max = {stretch_max}d0
+  gamma_max = {gamma_max}d0
+  v = zero; a = zero; params = zero; energy = zero
+  adlmag = zero; ddlmag = zero; predef = zero; jdltyp = 0
+  period = zero
+
+{coords_lines}
+
+  time = zero
+  call uexternaldb(0, 0, time, zero, 0, 0)
+  call execute_command_line('mkdir -p results')
+
+  ! Uniaxial: F = diag(s, 1/sqrt(s), 1/sqrt(s))
+  Ftar = zero
+  Ftar(1,1) = stretch_max
+  Ftar(2,2) = one/sqrt(stretch_max); Ftar(3,3) = one/sqrt(stretch_max)
+  call run_case(Ftar, 'results/uel_uniaxial.dat', 'Uniaxial ')
+
+  ! Biaxial: F = diag(s, s, 1/s^2)
+  Ftar = zero
+  Ftar(1,1) = stretch_max; Ftar(2,2) = stretch_max
+  Ftar(3,3) = one/(stretch_max*stretch_max)
+  call run_case(Ftar, 'results/uel_biaxial.dat', 'Biaxial  ')
+
+  ! Pure shear: F12 = F21 = gamma
+  Ftar = zero; Ftar(1,1) = one; Ftar(2,2) = one; Ftar(3,3) = one
+  Ftar(1,2) = gamma_max; Ftar(2,1) = gamma_max
+  call run_case(Ftar, 'results/uel_shear.dat', 'Shear    ')
+
+  ! Simple shear: F12 = gamma
+  Ftar = zero; Ftar(1,1) = one; Ftar(2,2) = one; Ftar(3,3) = one
+  Ftar(1,2) = gamma_max
+  call run_case(Ftar, 'results/uel_simple_shear.dat', 'Simple sh')
+
+contains
+
+  !> Ramp the element from I to Ftar in nsteps affine increments,
+  !> carrying svars (state) across increments.
+  subroutine run_case(Ft, fname, label)
+    double precision, intent(in) :: Ft(3,3)
+    character(*), intent(in) :: fname, label
+    double precision :: F(3,3), uold(ndofel), fface(3), s
+    integer :: i, n, k, kk, face_nodes(4)
+
+    face_nodes = (/2, 3, 6, 7/)   ! x+ face (X=1)
+    svars = zero; u = zero; uold = zero; time = zero
+    pnewdt = one
+
+    open(unit=21, file=fname, status='replace')
+    do i = 1, nsteps
+      s = dble(i)/dble(nsteps)
+      F = identity3() + s*(Ft - identity3())
+      ! Affine nodal displacements u_a = (F - I) X_a
+      do n = 1, nnode
+        do k = 1, 3
+          u(3*(n-1)+k) = sum((F(k,:) - identity_row(k))*coords(:,n))
+        end do
+      end do
+      du(:,1) = u - uold
+      rhs = zero; amatrx = zero
+      call uel(rhs, amatrx, svars, energy, ndofel, nrhs, nsvars, &
+               props, nprops, coords, mcrd, nnode, u, du, v, a, jtype, &
+               time, dtime, 1, i, jelem, params, ndload, jdltyp, adlmag, &
+               predef, npredf, lflags, mlvarx, ddlmag, mdload, pnewdt, &
+               jprops, njprop, period)
+      ! Internal force on the x+ face: f = -sum(RHS) over face nodes
+      fface = zero
+      do kk = 1, 4
+        n = face_nodes(kk)
+        do k = 1, 3
+          fface(k) = fface(k) - rhs(3*(n-1)+k, 1)
+        end do
+      end do
+      write(21, '(5ES20.10)') time(1), s, fface(1), fface(2), fface(3)
+      time(1) = time(1) + dtime
+      uold = u
+    end do
+    close(21)
+    write(*,'(A,A,A)') label, ' -> ', fname
+  end subroutine run_case
+
+  pure function identity3() result(iden)
+    double precision :: iden(3,3)
+    integer :: ii
+    iden = 0.0d0
+    do ii = 1, 3
+      iden(ii,ii) = 1.0d0
+    end do
+  end function identity3
+
+  pure function identity_row(k) result(row)
+    integer, intent(in) :: k
+    double precision :: row(3)
+    row = 0.0d0
+    row(k) = 1.0d0
+  end function identity_row
+
+end program test_uel
+
+! Stub for ABAQUS-provided routine (standalone builds only)
+subroutine getoutdir(outdir, lenoutdir)
+  implicit none
+  character(len=256), intent(out) :: outdir
+  integer, intent(out) :: lenoutdir
+  outdir = '.'
+  lenoutdir = 1
+end subroutine getoutdir
+"""
+    (outdir / "test_uel.f90").write_text(code)
+
+
+def generate_uel_abaqus(outdir, cfg, elem):
+    """ABAQUS single-element UEL deck: U3 real mesh + dummy mesh for UVARM
+    visualization. Reuses the bcs_*.inp files written by generate_abaqus_dir
+    (same node numbering and node sets)."""
+    abq = outdir / "abaqus"
+    abq.mkdir(exist_ok=True)
+
+    props = build_props(cfg)
+    nprops = len(props)
+    nstatev = compute_nstatev(cfg)
+    nvars = elem["nint"] * nstatev
+    offset = elem["elem_offset"]
+    dummy_type = "C3D8" if elem["nint"] == 8 else "C3D8R"
+
+    # *UEL PROPERTY data: reals first, the two integer properties last
+    uel_props = fmt_props_abaqus(list(props) + [nstatev, nstatev])
+
+    deck = f"""\
+*Heading
+UEL single-element test — {cfg["name"]}
+** Real mesh: user element U3 (8-node brick, F-bar={'on' if elem['fbar'] else 'off'}, {elem['nint']}-pt)
+** Dummy mesh: {dummy_type} at element offset {offset}, carries UVARM output
+*Node, nset=all_nodes
+      1,           1.,           1.,           1.
+      2,           1.,           0.,           1.
+      3,           1.,           1.,           0.
+      4,           1.,           0.,           0.
+      5,           0.,           1.,           1.
+      6,           0.,           0.,           1.
+      7,           0.,           1.,           0.
+      8,           0.,           0.,           0.
+*User Element, type=U3, nodes=8, coordinates=3, properties={nprops}, iproperties=2, variables={nvars}, unsymm
+1,2,3
+*Element, type=U3, elset=main_element
+1, 5, 6, 8, 7, 1, 2, 4, 3
+*Element, type={dummy_type}, elset=dummy_mesh
+{1 + offset}, 5, 6, 8, 7, 1, 2, 4, 3
+*Nset, nset=Set-1, generate
+ 2,  8,  2
+*Nset, nset=Set-2, generate
+ 1,  7,  2
+*Nset, nset=Set-3
+ 1, 2, 5, 6
+*Nset, nset=Set-4, generate
+ 5,  8,  1
+*Nset, nset=Set-5
+ 2, 4, 6, 8
+*Nset, nset=Set-6
+ 3, 4, 7, 8
+*Nset, nset=Set-7, generate
+ 1, 4, 1
+*Uel Property, elset=main_element
+{uel_props}
+*Solid Section, elset=dummy_mesh, material=dummy_material
+*Material, name=dummy_material
+*User output variables
+{nstatev},
+*Elastic
+1.e-20
+*Step, name=static, nlgeom=YES, unsymm=YES, inc=200
+*Static
+0.01, 1., 1e-05, 0.1
+*INCLUDE, file=bcs_uni.inp
+*OUTPUT,FIELD,VARIABLE=PRESELECT,FREQ=1
+*ELEMENT OUTPUT, elset=dummy_mesh
+UVARM
+*OUTPUT,HISTORY,VARIABLE=PRESELECT,FREQ=1
+*End Step
+"""
+    (abq / "uel_cube.inp").write_text(deck)
+
+    run_sh = """\
+#!/bin/bash
+# Run ABAQUS single-element UEL test
+# Usage: ./run_uel.sh [bcs_file]
+BCS=${1:-bcs_uni.inp}
+sed -i "s/INCLUDE, file=bcs_.*/INCLUDE, file=${BCS}/" uel_cube.inp
+abaqus job=uel_cube user=../uel.f90 interactive
+"""
+    run_path = abq / "run_uel.sh"
+    run_path.write_text(run_sh)
+    run_path.chmod(run_path.stat().st_mode | stat.S_IEXEC)
+
+
 def generate_test_driver(outdir, cfg):
     props = build_props(cfg)
     nprops = len(props)
@@ -507,21 +819,31 @@ end subroutine getoutdir
     (outdir / "test_umat.f90").write_text(code)
 
 
-def generate_makefile(outdir):
-    mk = """\
+def generate_makefile(outdir, elem=None):
+    uel_all = " test_uel" if elem else ""
+    mk = f"""\
 FC      = gfortran
 FFLAGS  = -O2 -ffree-form
 
-all: test_umat
+all: test_umat{uel_all}
 
 test_umat: umat.f90 test_umat.f90
 \t$(FC) $(FFLAGS) -o $@ $^
 
 run: test_umat
 \t./test_umat
+"""
+    if elem:
+        mk += """
+test_uel: uel.f90 test_uel.f90
+\t$(FC) $(FFLAGS) -o $@ $^
 
+run_uel: test_uel
+\t./test_uel
+"""
+    mk += """
 clean:
-\trm -f test_umat *.mod
+\trm -f test_umat test_uel *.mod
 \trm -rf results
 """
     (outdir / "Makefile").write_text(mk)
@@ -743,12 +1065,18 @@ def generate(cfg):
     outdir = SCRIPT_DIR / name
     outdir.mkdir(exist_ok=True)
 
+    elem = element_cfg(cfg)
+
     generate_umat_f90(outdir)
     generate_aba_param(outdir)
     generate_test_driver(outdir, cfg)
-    generate_makefile(outdir)
+    generate_makefile(outdir, elem)
     generate_abaqus_dir(outdir, cfg)
     generate_quadrature(outdir, cfg)
+    if elem:
+        generate_uel_f90(outdir, cfg, elem)
+        generate_uel_test_driver(outdir, cfg, elem)
+        generate_uel_abaqus(outdir, cfg, elem)
 
     # Save the config for reproducibility
     (outdir / "config.json").write_text(json.dumps(cfg, indent=2) + "\n")
@@ -769,7 +1097,16 @@ def generate(cfg):
     print(f"    bcs_bi.inp      Biaxial boundary conditions")
     print(f"    bcs_sh.inp      Shear boundary conditions")
     print(f"    run.sh          ABAQUS submission script")
+    if elem:
+        nvars = elem["nint"] * nstatev
+        print(f"  uel.f90           User element + material library "
+              f"(U3, {elem['nint']}-pt, F-bar={'on' if elem['fbar'] else 'off'}, Variables={nvars})")
+        print(f"  test_uel.f90      Standalone single-element driver")
+        print(f"    abaqus/uel_cube.inp + run_uel.sh   ABAQUS UEL test")
+
     print(f"\nStandalone test:  cd {name} && make run")
+    if elem:
+        print(f"UEL test:         cd {name} && make run_uel")
     print(f"ABAQUS test:      cd {name}/abaqus && ./run.sh")
 
 
@@ -781,6 +1118,10 @@ def main():
     parser.add_argument("--example", metavar="NAME",
                         help="Generate from built-in example: " + ", ".join(EXAMPLES.keys()))
     parser.add_argument("--list", action="store_true", help="List available model types")
+    parser.add_argument("--uel", action="store_true",
+                        help="Also emit a user element (uel.f90 + test_uel.f90 + ABAQUS "
+                             "UEL deck) driven by this material; configs may instead "
+                             "carry an explicit \"element\" block")
     args = parser.parse_args()
 
     if args.list:
@@ -792,13 +1133,17 @@ def main():
             print(f"Unknown example: {args.example}")
             print(f"Available: {', '.join(EXAMPLES.keys())}")
             sys.exit(1)
-        cfg = EXAMPLES[args.example]
+        cfg = dict(EXAMPLES[args.example])
+        if args.uel:
+            cfg.setdefault("element", {})
         generate(cfg)
         return
 
     if args.config:
         with open(args.config) as f:
             cfg = json.load(f)
+        if args.uel:
+            cfg.setdefault("element", {})
         generate(cfg)
         return
 

--- a/src/element/mod_uel_config.f90
+++ b/src/element/mod_uel_config.f90
@@ -1,0 +1,16 @@
+!> @brief Mesh-dependent UEL configuration and the global SDV transfer array.
+!>
+!> globalSdv carries state variables from the UEL to UVARM so they can be
+!> visualized on a dummy mesh that overlays the real (UEL) mesh.
+module uel_config
+  implicit none
+
+  ! Mesh-dependent settings. generate.py rewrites the parameter VALUES below
+  ! when emitting uel.f90 for a model directory — keep each on its own line.
+  integer, parameter :: numElem    = 1      ! number of UEL elements in the real mesh
+  integer, parameter :: ElemOffset = 1000   ! element-number offset of the dummy mesh
+  logical, parameter :: use_fbar   = .true. ! F-bar (de Souza Neto 1996) on the 8pt brick
+  integer, parameter :: nIntPt     = 8      ! volume integration points (1 or 8)
+  real(8), allocatable :: globalSdv(:,:,:)  ! (element, integ point, sdv)
+
+end module uel_config

--- a/src/element/mod_uel_element.f90
+++ b/src/element/mod_uel_element.f90
@@ -1,0 +1,547 @@
+!> @brief 8-node brick user element (U3D8) for large-deformation mechanics.
+!>
+!> Locking is avoided for the fully-integrated element with the F-bar method:
+!>   de Souza Neto, E.A., Peric, D., Dutko, M., Owen, D.R.J., 1996.
+!>   Design of simple low order finite elements for large strain analysis of
+!>   nearly incompressible solids. Int. J. Solids Structures, 33, 3277-3296.
+!>
+!> The constitutive response is provided by material_uel (mod_material).
+module uel_element
+  use mod_constants, only: dp, ZERO, ONE, TWO, THREE, HALF, THIRD
+  use uel_config, only: numElem, globalSdv, use_fbar
+  use uel_shape, only: calcShape3DLinear, mapShape3D, xint3D1pt, xint3D8pt, &
+                       mdet, identity3
+  use mod_material, only: material_uel
+  implicit none
+  private
+  public :: u3d8, AssembleElement
+
+contains
+
+  subroutine u3d8(rhs, amatrx, svars, energy, ndofel, nrhs, nsvars, &
+                  props, nprops, coords, mcrd, nNode, Uall, DUall, Vel, Accn, &
+                  jtype, time, dtime, kstep, kinc, jelem, params, ndload, &
+                  jdltyp, adlmag, predef, npredf, lflags, mlvarx, ddlmag, &
+                  mdload, pnewdt, jprops, njprop, period, nDim, nIntt)
+
+    ! Variables passed in
+    integer, intent(in)  :: ndofel, nrhs, nsvars, nprops, mcrd, nNode, jtype
+    integer, intent(in)  :: kstep, kinc, jelem, ndload, npredf, mlvarx
+    integer, intent(in)  :: mdload, njprop, nDim, nIntt
+    integer, intent(in)  :: jdltyp(mdload,1), lflags(4), jprops(njprop)
+
+    ! Variables defined here, passed back to ABAQUS
+    real(dp), intent(inout) :: rhs(mlvarx,1), amatrx(ndofel,ndofel)
+    real(dp), intent(inout) :: svars(nsvars), energy(8), pnewdt
+
+    real(dp), intent(in) :: props(nprops), coords(mcrd,nNode), Uall(ndofel)
+    real(dp), intent(in) :: DUall(mlvarx,1), Vel(ndofel), Accn(ndofel)
+    real(dp), intent(in) :: time(2), dtime, params(1), adlmag(mdload,1)
+    real(dp), intent(in) :: predef(2,npredf,nNode), ddlmag(mdload,1), period
+
+    ! Locals
+    integer :: i, j, k, kk, jj, intpt, nInttPt, stat, nlSdv, ngSdv
+    real(dp), allocatable :: statev(:)
+    real(dp) :: u(nNode,3), du(nNode,ndofel), uOld(nNode,ndofel)
+    real(dp) :: coordsC(mcrd,nNode)
+    real(dp) :: Iden(3,3), Le, Ru(3*nNode,1), body(3)
+    real(dp) :: Kuu(3*nNode,3*nNode), sh0(nNode), detMapJ0
+    real(dp) :: dshxi(nNode,3), dsh0(nNode,3), dshC0(nNode,3), detMapJ0C
+    real(dp) :: Fc_tau(3,3), Fc_t(3,3), detFc_tau, detFc_t
+    real(dp) :: xi(nIntt,3), xi0(nIntt,3), w(nIntt)
+    real(dp) :: sh(nNode), detMapJ, dsh(nNode,3), detMapJC, dshC(nNode,3)
+    real(dp) :: F_tau(3,3), F_t(3,3), detF_tau, detF_t
+    real(dp) :: T_tau(3,3), SpTanMod(3,3,3,3), sse_ip
+    real(dp) :: predloc(1), dpredloc(1)
+    real(dp) :: Smat(6,1), Bmat(6,3*nNode), BodyForceRes(3*nNode,1)
+    real(dp) :: Gmat(9,3*nNode), G0mat(9,3*nNode), Amat(9,9), Qmat(9,9)
+
+    ! Get element parameters
+    nlSdv = jprops(1) ! number of local sdv's per integ point
+    ngSdv = jprops(2) ! number of global sdv's per integ point
+    allocate(statev(nlSdv))
+    xi0 = ZERO
+
+    ! Allocate memory for the globalSdv's used for viewing results
+    ! on the dummy mesh
+    if (.not. allocated(globalSdv)) then
+      allocate(globalSdv(numElem,nIntt,ngSdv), stat=stat)
+      if (stat /= 0) then
+        write(*,*) 'U3D8: error when allocating globalSdv, stat=', stat
+        write(*,*) '  numElem=', numElem, ' nIntt=', nIntt, ' ngSdv=', ngSdv
+        call exit(1)
+      end if
+      write(*,*) 'U3D8: globalSdv allocated with numElem=', numElem, &
+                 ' nIntt=', nIntt, ' ngSdv=', ngSdv
+    end if
+
+    ! Identity tensor
+    call identity3(Iden)
+
+    ! Initialize the residual and tangent matrices to zero
+    Ru = ZERO
+    Kuu = ZERO
+
+    ! Body forces
+    body(1:3) = ZERO
+
+    ! Obtain nodal displacements
+    k = 0
+    do i = 1, nNode
+      do j = 1, nDim
+        k = k + 1
+        u(i,j) = Uall(k)
+        du(i,j) = DUall(k,1)
+        uOld(i,j) = u(i,j) - du(i,j)
+      end do
+    end do
+
+    ! Obtain current nodal coordinates
+    do i = 1, nNode
+      do j = 1, nDim
+        coordsC(j,i) = coords(j,i) + u(i,j)
+      end do
+    end do
+
+    ! Impose any time-stepping changes on the increments of displacement;
+    ! displacement increment check based on element diagonal
+    Le = sqrt(((coordsC(1,1) - coordsC(1,7))**TWO) &
+            + ((coordsC(2,1) - coordsC(2,7))**TWO) &
+            + ((coordsC(3,1) - coordsC(3,7))**TWO))
+    !
+    do i = 1, nNode
+      do j = 1, nDim
+        if (abs(du(i,j)) > 10.0_dp*Le) then
+          pnewdt = HALF
+          return
+        end if
+      end do
+    end do
+
+    !--------------------------------------------------------------------
+    ! Take this opportunity to perform calculations at the element
+    ! centroid. Get the deformation gradient for use in the F-bar method.
+    !
+    ! Obtain shape functions and their local gradients at the element
+    ! centroid, that means xi=eta=zeta=0.0, and nInttPt=1
+    if (nNode == 8) then
+      call calcShape3DLinear(1, xi0, 1, sh0, dshxi)
+    else
+      write(*,*) 'Incorrect number of nodes: nNode.ne.8'
+      call exit(1)
+    end if
+
+    ! Map shape functions from local to global reference coordinate system
+    call mapShape3D(nNode, dshxi, coords, dsh0, detMapJ0, stat)
+    if (stat == 0) then
+      pnewdt = HALF
+      return
+    end if
+
+    ! Map shape functions from local to global current coordinate system
+    call mapShape3D(nNode, dshxi, coordsC, dshC0, detMapJ0C, stat)
+    if (stat == 0) then
+      pnewdt = HALF
+      return
+    end if
+
+    ! Calculate the deformation gradient at the element centroid at the
+    ! beginning and end of the increment for use in the F-bar method
+    Fc_tau = Iden
+    Fc_t = Iden
+    do i = 1, nDim
+      do j = 1, nDim
+        do k = 1, nNode
+          ! F at the end of the increment
+          Fc_tau(i,j) = Fc_tau(i,j) + dsh0(k,j)*u(k,i)
+          ! F at the beginning of the increment
+          Fc_t(i,j) = Fc_t(i,j) + dsh0(k,j)*uOld(k,i)
+        end do
+      end do
+    end do
+    !
+    call mdet(Fc_tau, detFc_tau)
+    call mdet(Fc_t, detFc_t)
+    !
+    ! With the deformation gradient known at the element centroid
+    ! we are now able to implement the F-bar method later
+    !--------------------------------------------------------------------
+
+    !--------------------------------------------------------------------
+    ! Begin the loop over integration points
+    !
+    ! Obtain integration point local coordinates and weights
+    if (nIntt == 1) then
+      call xint3D1pt(xi, w, nInttPt) ! 1-pt integration
+    else if (nIntt == 8) then
+      call xint3D8pt(xi, w, nInttPt) ! 8-pt integration
+    else
+      write(*,*) 'Invalid number of int points, nIntt=', nIntt
+      call exit(1)
+    end if
+
+    ! Loop over integration points
+    jj = 0 ! jj is used for tracking the state variables
+    do intpt = 1, nInttPt
+
+      ! Obtain state variables from previous increment
+      if ((kinc <= 1) .and. (kstep == 1)) then
+        ! this is the first increment of the first step:
+        ! give initial conditions
+        statev = ZERO
+      else
+        ! this is not the first increment, read old values
+        statev = svars(1+jj:nlSdv+jj)
+      end if
+
+      ! Obtain shape functions and their local gradients
+      if (nNode == 8) then
+        call calcShape3DLinear(nInttPt, xi, intpt, sh, dshxi)
+      else
+        write(*,*) 'Incorrect number of nodes: nNode.ne.8'
+        call exit(1)
+      end if
+
+      ! Map shape functions from local to global reference coordinate system
+      call mapShape3D(nNode, dshxi, coords, dsh, detMapJ, stat)
+      if (stat == 0) then
+        pnewdt = HALF
+        return
+      end if
+
+      ! Map shape functions from local to global current coordinate system
+      call mapShape3D(nNode, dshxi, coordsC, dshC, detMapJC, stat)
+      if (stat == 0) then
+        pnewdt = HALF
+        return
+      end if
+
+      ! Obtain the deformation gradient at this integration point
+      F_tau = Iden
+      F_t = Iden
+      do i = 1, nDim
+        do j = 1, nDim
+          do k = 1, nNode
+            F_tau(i,j) = F_tau(i,j) + dsh(k,j)*u(k,i)
+            F_t(i,j) = F_t(i,j) + dsh(k,j)*uOld(k,i)
+          end do
+        end do
+      end do
+      !
+      ! Modify the deformation gradient for the F-bar method, only when
+      ! using the 8-node fully-integrated linear element
+      if (use_fbar .and. nNode == 8 .and. nIntt == 8) then
+        call mdet(F_tau, detF_tau)
+        call mdet(F_t, detF_t)
+        F_tau = ((detFc_tau/detF_tau)**THIRD)*F_tau
+        F_t = ((detFc_tau/detF_tau)**THIRD)*F_t
+      end if
+
+      !@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+      !
+      ! Constitutive update at this integration point: Cauchy stress,
+      ! UEL assembly tangent, and state variables. pnewdt is governed by
+      ! material_uel (element-inversion cutback).
+      !
+      ! Field-variable interpolation to the integration point is not
+      ! implemented; the first nodal value is forwarded as-is.
+      predloc(1) = predef(1,1,1)
+      dpredloc(1) = ZERO
+      !
+      call material_uel(T_tau, SpTanMod, sse_ip, &
+                        statev, nlSdv, props, nprops, F_tau, &
+                        time, dtime, predloc, dpredloc, pnewdt, &
+                        jelem, intpt, kstep, kinc)
+      !
+      !@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+      ! Save the state variables at this integ point at the end
+      ! of the increment
+      svars(1+jj:nlSdv+jj) = statev
+      jj = jj + nlSdv ! setup for the next intpt
+
+      ! Save the state variables at this integ point in the global
+      ! array used for plotting field output
+      globalSdv(jelem,intpt,1:ngSdv) = statev(1:ngSdv)
+
+      ! Compute/update the displacement residual vector
+      Smat(1,1) = T_tau(1,1)
+      Smat(2,1) = T_tau(2,2)
+      Smat(3,1) = T_tau(3,3)
+      Smat(4,1) = T_tau(1,2)
+      Smat(5,1) = T_tau(2,3)
+      Smat(6,1) = T_tau(1,3)
+      !
+      Bmat = ZERO
+      do kk = 1, nNode
+        Bmat(1,1+nDim*(kk-1)) = dshC(kk,1)
+        Bmat(2,2+nDim*(kk-1)) = dshC(kk,2)
+        Bmat(3,3+nDim*(kk-1)) = dshC(kk,3)
+        Bmat(4,1+nDim*(kk-1)) = dshC(kk,2)
+        Bmat(4,2+nDim*(kk-1)) = dshC(kk,1)
+        Bmat(5,2+nDim*(kk-1)) = dshC(kk,3)
+        Bmat(5,3+nDim*(kk-1)) = dshC(kk,2)
+        Bmat(6,1+nDim*(kk-1)) = dshC(kk,3)
+        Bmat(6,3+nDim*(kk-1)) = dshC(kk,1)
+      end do
+      !
+      BodyForceRes = ZERO
+      do kk = 1, nNode
+        BodyForceRes(1+nDim*(kk-1),1) = sh(kk)*body(1)
+        BodyForceRes(2+nDim*(kk-1),1) = sh(kk)*body(2)
+        BodyForceRes(3+nDim*(kk-1),1) = sh(kk)*body(3)
+      end do
+      !
+      Ru = Ru + detMapJC*w(intpt)* &
+           ( &
+           -matmul(transpose(Bmat),Smat) &
+           + BodyForceRes &
+           )
+
+      ! Compute/update the displacement tangent matrix
+      Gmat = ZERO
+      do kk = 1, nNode
+        Gmat(1,1+nDim*(kk-1)) = dshC(kk,1)
+        Gmat(2,2+nDim*(kk-1)) = dshC(kk,1)
+        Gmat(3,3+nDim*(kk-1)) = dshC(kk,1)
+        Gmat(4,1+nDim*(kk-1)) = dshC(kk,2)
+        Gmat(5,2+nDim*(kk-1)) = dshC(kk,2)
+        Gmat(6,3+nDim*(kk-1)) = dshC(kk,2)
+        Gmat(7,1+nDim*(kk-1)) = dshC(kk,3)
+        Gmat(8,2+nDim*(kk-1)) = dshC(kk,3)
+        Gmat(9,3+nDim*(kk-1)) = dshC(kk,3)
+      end do
+
+      G0mat = ZERO
+      do kk = 1, nNode
+        G0mat(1,1+nDim*(kk-1)) = dshC0(kk,1)
+        G0mat(2,2+nDim*(kk-1)) = dshC0(kk,1)
+        G0mat(3,3+nDim*(kk-1)) = dshC0(kk,1)
+        G0mat(4,1+nDim*(kk-1)) = dshC0(kk,2)
+        G0mat(5,2+nDim*(kk-1)) = dshC0(kk,2)
+        G0mat(6,3+nDim*(kk-1)) = dshC0(kk,2)
+        G0mat(7,1+nDim*(kk-1)) = dshC0(kk,3)
+        G0mat(8,2+nDim*(kk-1)) = dshC0(kk,3)
+        G0mat(9,3+nDim*(kk-1)) = dshC0(kk,3)
+      end do
+
+      Amat = ZERO
+      Amat(1,1) = SpTanMod(1,1,1,1)
+      Amat(1,2) = SpTanMod(1,1,2,1)
+      Amat(1,3) = SpTanMod(1,1,3,1)
+      Amat(1,4) = SpTanMod(1,1,1,2)
+      Amat(1,5) = SpTanMod(1,1,2,2)
+      Amat(1,6) = SpTanMod(1,1,3,2)
+      Amat(1,7) = SpTanMod(1,1,1,3)
+      Amat(1,8) = SpTanMod(1,1,2,3)
+      Amat(1,9) = SpTanMod(1,1,3,3)
+      Amat(2,1) = SpTanMod(2,1,1,1)
+      Amat(2,2) = SpTanMod(2,1,2,1)
+      Amat(2,3) = SpTanMod(2,1,3,1)
+      Amat(2,4) = SpTanMod(2,1,1,2)
+      Amat(2,5) = SpTanMod(2,1,2,2)
+      Amat(2,6) = SpTanMod(2,1,3,2)
+      Amat(2,7) = SpTanMod(2,1,1,3)
+      Amat(2,8) = SpTanMod(2,1,2,3)
+      Amat(2,9) = SpTanMod(2,1,3,3)
+      Amat(3,1) = SpTanMod(3,1,1,1)
+      Amat(3,2) = SpTanMod(3,1,2,1)
+      Amat(3,3) = SpTanMod(3,1,3,1)
+      Amat(3,4) = SpTanMod(3,1,1,2)
+      Amat(3,5) = SpTanMod(3,1,2,2)
+      Amat(3,6) = SpTanMod(3,1,3,2)
+      Amat(3,7) = SpTanMod(3,1,1,3)
+      Amat(3,8) = SpTanMod(3,1,2,3)
+      Amat(3,9) = SpTanMod(3,1,3,3)
+      Amat(4,1) = SpTanMod(1,2,1,1)
+      Amat(4,2) = SpTanMod(1,2,2,1)
+      Amat(4,3) = SpTanMod(1,2,3,1)
+      Amat(4,4) = SpTanMod(1,2,1,2)
+      Amat(4,5) = SpTanMod(1,2,2,2)
+      Amat(4,6) = SpTanMod(1,2,3,2)
+      Amat(4,7) = SpTanMod(1,2,1,3)
+      Amat(4,8) = SpTanMod(1,2,2,3)
+      Amat(4,9) = SpTanMod(1,2,3,3)
+      Amat(5,1) = SpTanMod(2,2,1,1)
+      Amat(5,2) = SpTanMod(2,2,2,1)
+      Amat(5,3) = SpTanMod(2,2,3,1)
+      Amat(5,4) = SpTanMod(2,2,1,2)
+      Amat(5,5) = SpTanMod(2,2,2,2)
+      Amat(5,6) = SpTanMod(2,2,3,2)
+      Amat(5,7) = SpTanMod(2,2,1,3)
+      Amat(5,8) = SpTanMod(2,2,2,3)
+      Amat(5,9) = SpTanMod(2,2,3,3)
+      Amat(6,1) = SpTanMod(3,2,1,1)
+      Amat(6,2) = SpTanMod(3,2,2,1)
+      Amat(6,3) = SpTanMod(3,2,3,1)
+      Amat(6,4) = SpTanMod(3,2,1,2)
+      Amat(6,5) = SpTanMod(3,2,2,2)
+      Amat(6,6) = SpTanMod(3,2,3,2)
+      Amat(6,7) = SpTanMod(3,2,1,3)
+      Amat(6,8) = SpTanMod(3,2,2,3)
+      Amat(6,9) = SpTanMod(3,2,3,3)
+      Amat(7,1) = SpTanMod(1,3,1,1)
+      Amat(7,2) = SpTanMod(1,3,2,1)
+      Amat(7,3) = SpTanMod(1,3,3,1)
+      Amat(7,4) = SpTanMod(1,3,1,2)
+      Amat(7,5) = SpTanMod(1,3,2,2)
+      Amat(7,6) = SpTanMod(1,3,3,2)
+      Amat(7,7) = SpTanMod(1,3,1,3)
+      Amat(7,8) = SpTanMod(1,3,2,3)
+      Amat(7,9) = SpTanMod(1,3,3,3)
+      Amat(8,1) = SpTanMod(2,3,1,1)
+      Amat(8,2) = SpTanMod(2,3,2,1)
+      Amat(8,3) = SpTanMod(2,3,3,1)
+      Amat(8,4) = SpTanMod(2,3,1,2)
+      Amat(8,5) = SpTanMod(2,3,2,2)
+      Amat(8,6) = SpTanMod(2,3,3,2)
+      Amat(8,7) = SpTanMod(2,3,1,3)
+      Amat(8,8) = SpTanMod(2,3,2,3)
+      Amat(8,9) = SpTanMod(2,3,3,3)
+      Amat(9,1) = SpTanMod(3,3,1,1)
+      Amat(9,2) = SpTanMod(3,3,2,1)
+      Amat(9,3) = SpTanMod(3,3,3,1)
+      Amat(9,4) = SpTanMod(3,3,1,2)
+      Amat(9,5) = SpTanMod(3,3,2,2)
+      Amat(9,6) = SpTanMod(3,3,3,2)
+      Amat(9,7) = SpTanMod(3,3,1,3)
+      Amat(9,8) = SpTanMod(3,3,2,3)
+      Amat(9,9) = SpTanMod(3,3,3,3)
+
+      Qmat = ZERO
+      Qmat(1,1) = THIRD*(Amat(1,1)+Amat(1,5)+Amat(1,9)) &
+                  - (TWO/THREE)*T_tau(1,1)
+      Qmat(2,1) = THIRD*(Amat(2,1)+Amat(2,5)+Amat(2,9)) &
+                  - (TWO/THREE)*T_tau(2,1)
+      Qmat(3,1) = THIRD*(Amat(3,1)+Amat(3,5)+Amat(3,9)) &
+                  - (TWO/THREE)*T_tau(3,1)
+      Qmat(4,1) = THIRD*(Amat(4,1)+Amat(4,5)+Amat(4,9)) &
+                  - (TWO/THREE)*T_tau(1,2)
+      Qmat(5,1) = THIRD*(Amat(5,1)+Amat(5,5)+Amat(5,9)) &
+                  - (TWO/THREE)*T_tau(2,2)
+      Qmat(6,1) = THIRD*(Amat(6,1)+Amat(6,5)+Amat(6,9)) &
+                  - (TWO/THREE)*T_tau(3,2)
+      Qmat(7,1) = THIRD*(Amat(7,1)+Amat(7,5)+Amat(7,9)) &
+                  - (TWO/THREE)*T_tau(1,3)
+      Qmat(8,1) = THIRD*(Amat(8,1)+Amat(8,5)+Amat(8,9)) &
+                  - (TWO/THREE)*T_tau(2,3)
+      Qmat(9,1) = THIRD*(Amat(9,1)+Amat(9,5)+Amat(9,9)) &
+                  - (TWO/THREE)*T_tau(3,3)
+      Qmat(1,5) = Qmat(1,1)
+      Qmat(2,5) = Qmat(2,1)
+      Qmat(3,5) = Qmat(3,1)
+      Qmat(4,5) = Qmat(4,1)
+      Qmat(5,5) = Qmat(5,1)
+      Qmat(6,5) = Qmat(6,1)
+      Qmat(7,5) = Qmat(7,1)
+      Qmat(8,5) = Qmat(8,1)
+      Qmat(9,5) = Qmat(9,1)
+      Qmat(1,9) = Qmat(1,1)
+      Qmat(2,9) = Qmat(2,1)
+      Qmat(3,9) = Qmat(3,1)
+      Qmat(4,9) = Qmat(4,1)
+      Qmat(5,9) = Qmat(5,1)
+      Qmat(6,9) = Qmat(6,1)
+      Qmat(7,9) = Qmat(7,1)
+      Qmat(8,9) = Qmat(8,1)
+      Qmat(9,9) = Qmat(9,1)
+
+      if (use_fbar .and. nNode == 8 .and. nIntt == 8) then
+        !
+        ! This is the tangent using the F-bar method with the
+        ! 8-node fully-integrated linear element
+        !
+        Kuu = Kuu + detMapJC*w(intpt)* &
+              ( &
+              matmul(matmul(transpose(Gmat),Amat),Gmat) &
+              + matmul(transpose(Gmat),matmul(Qmat,(G0mat-Gmat))) &
+              )
+      else
+        !
+        ! This is the tangent NOT using the F-bar method with all
+        ! other elements
+        !
+        Kuu = Kuu + detMapJC*w(intpt)* &
+              ( &
+              matmul(matmul(transpose(Gmat),Amat),Gmat) &
+              )
+      end if
+
+    end do
+    !
+    ! End the loop over integration points
+    !--------------------------------------------------------------------
+
+    !--------------------------------------------------------------------
+    ! Return to Abaqus the RHS vector and the stiffness matrix
+    !
+    call AssembleElement(nDim, nNode, ndofel, Ru, Kuu, rhs, amatrx)
+    !
+    ! End return of RHS and AMATRX
+    !--------------------------------------------------------------------
+
+  end subroutine u3d8
+
+  !> Assemble the local element residual and tangent (mechanical only):
+  !> maps Ru -> rhs and Kuu -> amatrx.
+  subroutine AssembleElement(nDim, nNode, ndofel, Ru, Kuu, rhs, amatrx)
+
+    integer, intent(in)   :: nDim, nNode, ndofel
+    real(dp), intent(in)  :: Ru(nDim*nNode,1), Kuu(nDim*nNode,nDim*nNode)
+    real(dp), intent(out) :: rhs(ndofel,1), amatrx(ndofel,ndofel)
+
+    integer :: i, j, A11, A12, B11, B12, nDofN
+
+    ! Total number of degrees of freedom per node
+    nDofN = ndofel/nNode
+
+    ! init
+    rhs = ZERO
+    amatrx = ZERO
+
+    if (nDim == 3) then
+      !
+      ! Assemble the element level residual
+      !
+      do i = 1, nNode
+        A11 = nDofN*(i-1) + 1
+        A12 = nDim*(i-1) + 1
+        !
+        ! displacement
+        !
+        rhs(A11,1)   = Ru(A12,1)
+        rhs(A11+1,1) = Ru(A12+1,1)
+        rhs(A11+2,1) = Ru(A12+2,1)
+      end do
+      !
+      ! Assemble the element level tangent matrix
+      !
+      do i = 1, nNode
+        do j = 1, nNode
+          A11 = nDofN*(i-1) + 1
+          A12 = nDim*(i-1) + 1
+          B11 = nDofN*(j-1) + 1
+          B12 = nDim*(j-1) + 1
+          !
+          ! displacement
+          !
+          amatrx(A11,B11)     = Kuu(A12,B12)
+          amatrx(A11,B11+1)   = Kuu(A12,B12+1)
+          amatrx(A11,B11+2)   = Kuu(A12,B12+2)
+          amatrx(A11+1,B11)   = Kuu(A12+1,B12)
+          amatrx(A11+1,B11+1) = Kuu(A12+1,B12+1)
+          amatrx(A11+1,B11+2) = Kuu(A12+1,B12+2)
+          amatrx(A11+2,B11)   = Kuu(A12+2,B12)
+          amatrx(A11+2,B11+1) = Kuu(A12+2,B12+1)
+          amatrx(A11+2,B11+2) = Kuu(A12+2,B12+2)
+        end do
+      end do
+      !
+    else
+      write(*,*) 'AssembleElement: unsupported nDim=', nDim
+      call exit(1)
+    end if
+
+  end subroutine AssembleElement
+
+end module uel_element

--- a/src/element/mod_uel_shape.f90
+++ b/src/element/mod_uel_shape.f90
@@ -1,0 +1,226 @@
+!> @brief Shape functions, Gauss schemes, and small matrix helpers for the
+!>        8-node brick user element (volume integration path only).
+module uel_shape
+  use mod_constants, only: dp, ZERO, ONE, THREE
+  use mod_tensor, only: matinv3d
+  implicit none
+  private
+  public :: calcShape3DLinear, mapShape3D, xint3D1pt, xint3D8pt, mdet, identity3
+
+  real(dp), parameter :: EIGHTH = ONE/8.0_dp
+
+contains
+
+  !> Integration point location and weight for 1-point Gauss integration
+  !> on the 8-node brick.
+  subroutine xint3D1pt(xi, w, nInttPt)
+    real(dp), intent(out) :: xi(1,3), w(1)
+    integer, intent(out)  :: nInttPt
+
+    ! Init
+    w = ZERO
+    xi = ZERO
+
+    ! Number of Gauss points
+    nInttPt = 1
+
+    ! Gauss weights
+    w(1) = 8.0_dp
+
+    ! Gauss pt locations in master element
+    xi(1,1) = ZERO
+    xi(1,2) = ZERO
+    xi(1,3) = ZERO
+
+  end subroutine xint3D1pt
+
+  !> Integration point locations and weights for 8-point Gauss integration
+  !> on the 8-node brick.
+  subroutine xint3D8pt(xi, w, nInttPt)
+    real(dp), intent(out) :: xi(8,3), w(8)
+    integer, intent(out)  :: nInttPt
+
+    ! Init
+    w = ZERO
+    xi = ZERO
+
+    ! Number of Gauss points
+    nInttPt = 8
+
+    ! Gauss weights
+    w(1) = ONE
+    w(2) = ONE
+    w(3) = ONE
+    w(4) = ONE
+    w(5) = ONE
+    w(6) = ONE
+    w(7) = ONE
+    w(8) = ONE
+
+    ! Gauss pt locations in master element
+    xi(1,1) = -sqrt(ONE/THREE)
+    xi(1,2) = -sqrt(ONE/THREE)
+    xi(1,3) = -sqrt(ONE/THREE)
+    xi(2,1) = sqrt(ONE/THREE)
+    xi(2,2) = -sqrt(ONE/THREE)
+    xi(2,3) = -sqrt(ONE/THREE)
+    xi(3,1) = -sqrt(ONE/THREE)
+    xi(3,2) = sqrt(ONE/THREE)
+    xi(3,3) = -sqrt(ONE/THREE)
+    xi(4,1) = sqrt(ONE/THREE)
+    xi(4,2) = sqrt(ONE/THREE)
+    xi(4,3) = -sqrt(ONE/THREE)
+    xi(5,1) = -sqrt(ONE/THREE)
+    xi(5,2) = -sqrt(ONE/THREE)
+    xi(5,3) = sqrt(ONE/THREE)
+    xi(6,1) = sqrt(ONE/THREE)
+    xi(6,2) = -sqrt(ONE/THREE)
+    xi(6,3) = sqrt(ONE/THREE)
+    xi(7,1) = -sqrt(ONE/THREE)
+    xi(7,2) = sqrt(ONE/THREE)
+    xi(7,3) = sqrt(ONE/THREE)
+    xi(8,1) = sqrt(ONE/THREE)
+    xi(8,2) = sqrt(ONE/THREE)
+    xi(8,3) = sqrt(ONE/THREE)
+
+  end subroutine xint3D8pt
+
+  !> Shape functions and their local derivatives at a given integration
+  !> point of the 8-node linear brick master element.
+  !>
+  !>      8-----------7
+  !>     /|          /|       zeta
+  !>    / |         / |
+  !>   5-----------6  |       |     eta
+  !>   |  |        |  |       |   /
+  !>   |  |        |  |       |  /
+  !>   |  4--------|--3       | /
+  !>   | /         | /        |/
+  !>   |/          |/         O--------- xi
+  !>   1-----------2        origin at cube center
+  !>
+  !> sh(i) = shape function of node i at the intpt
+  !> dshxi(i,j) = derivative wrt j direction of shape fn of node i
+  subroutine calcShape3DLinear(nInttPt, xi_int, intpt, sh, dshxi)
+    integer, intent(in)   :: nInttPt, intpt
+    real(dp), intent(in)  :: xi_int(nInttPt,3)
+    real(dp), intent(out) :: sh(8), dshxi(8,3)
+
+    real(dp) :: xi, eta, zeta
+
+    ! Location in the master element
+    xi = xi_int(intpt,1)
+    eta = xi_int(intpt,2)
+    zeta = xi_int(intpt,3)
+
+    ! The shape functions
+    sh(1) = EIGHTH*(ONE - xi)*(ONE - eta)*(ONE - zeta)
+    sh(2) = EIGHTH*(ONE + xi)*(ONE - eta)*(ONE - zeta)
+    sh(3) = EIGHTH*(ONE + xi)*(ONE + eta)*(ONE - zeta)
+    sh(4) = EIGHTH*(ONE - xi)*(ONE + eta)*(ONE - zeta)
+    sh(5) = EIGHTH*(ONE - xi)*(ONE - eta)*(ONE + zeta)
+    sh(6) = EIGHTH*(ONE + xi)*(ONE - eta)*(ONE + zeta)
+    sh(7) = EIGHTH*(ONE + xi)*(ONE + eta)*(ONE + zeta)
+    sh(8) = EIGHTH*(ONE - xi)*(ONE + eta)*(ONE + zeta)
+
+    ! The first derivatives
+    dshxi(1,1) = -EIGHTH*(ONE - eta)*(ONE - zeta)
+    dshxi(1,2) = -EIGHTH*(ONE - xi)*(ONE - zeta)
+    dshxi(1,3) = -EIGHTH*(ONE - xi)*(ONE - eta)
+    dshxi(2,1) = EIGHTH*(ONE - eta)*(ONE - zeta)
+    dshxi(2,2) = -EIGHTH*(ONE + xi)*(ONE - zeta)
+    dshxi(2,3) = -EIGHTH*(ONE + xi)*(ONE - eta)
+    dshxi(3,1) = EIGHTH*(ONE + eta)*(ONE - zeta)
+    dshxi(3,2) = EIGHTH*(ONE + xi)*(ONE - zeta)
+    dshxi(3,3) = -EIGHTH*(ONE + xi)*(ONE + eta)
+    dshxi(4,1) = -EIGHTH*(ONE + eta)*(ONE - zeta)
+    dshxi(4,2) = EIGHTH*(ONE - xi)*(ONE - zeta)
+    dshxi(4,3) = -EIGHTH*(ONE - xi)*(ONE + eta)
+    dshxi(5,1) = -EIGHTH*(ONE - eta)*(ONE + zeta)
+    dshxi(5,2) = -EIGHTH*(ONE - xi)*(ONE + zeta)
+    dshxi(5,3) = EIGHTH*(ONE - xi)*(ONE - eta)
+    dshxi(6,1) = EIGHTH*(ONE - eta)*(ONE + zeta)
+    dshxi(6,2) = -EIGHTH*(ONE + xi)*(ONE + zeta)
+    dshxi(6,3) = EIGHTH*(ONE + xi)*(ONE - eta)
+    dshxi(7,1) = EIGHTH*(ONE + eta)*(ONE + zeta)
+    dshxi(7,2) = EIGHTH*(ONE + xi)*(ONE + zeta)
+    dshxi(7,3) = EIGHTH*(ONE + xi)*(ONE + eta)
+    dshxi(8,1) = -EIGHTH*(ONE + eta)*(ONE + zeta)
+    dshxi(8,2) = EIGHTH*(ONE - xi)*(ONE + zeta)
+    dshxi(8,3) = EIGHTH*(ONE - xi)*(ONE + eta)
+
+  end subroutine calcShape3DLinear
+
+  !> Map derivatives of shape functions from the xi-eta-zeta domain to the
+  !> x-y-z domain. Returns stat=0 (without modifying dsh) if the mapping
+  !> Jacobian determinant is non-positive, so the caller can cut back.
+  subroutine mapShape3D(nNode, dshxi, coords, dsh, detMapJ, stat)
+    integer, intent(in)   :: nNode
+    real(dp), intent(in)  :: dshxi(nNode,3), coords(3,nNode)
+    real(dp), intent(out) :: dsh(nNode,3), detMapJ
+    integer, intent(out)  :: stat
+
+    integer  :: i, j, k
+    real(dp) :: mapJ(3,3), mapJ_inv(3,3)
+
+    stat = 1
+
+    ! Calculate the mapping Jacobian matrix
+    mapJ = ZERO
+    do i = 1, 3
+      do j = 1, 3
+        do k = 1, nNode
+          mapJ(i,j) = mapJ(i,j) + dshxi(k,i)*coords(j,k)
+        end do
+      end do
+    end do
+
+    ! Determinant check: a non-positive mapping Jacobian flags a bad
+    ! (inverted) element configuration
+    call mdet(mapJ, detMapJ)
+    if (detMapJ <= ZERO) then
+      write(*,*) 'WARNING: mapShape3D: det of mapping Jacobian =', detMapJ
+      stat = 0
+      return
+    end if
+
+    ! Calculate the inverse of the Jacobian (reused from mod_tensor)
+    call matinv3d(mapJ, mapJ_inv)
+
+    ! Calculate first derivatives wrt x, y, z
+    dsh = transpose(matmul(mapJ_inv, transpose(dshxi)))
+
+  end subroutine mapShape3D
+
+  !> Determinant of a 3x3 matrix.
+  subroutine mdet(A, det)
+    real(dp), intent(in)  :: A(3,3)
+    real(dp), intent(out) :: det
+
+    det = A(1,1)*A(2,2)*A(3,3) &
+        + A(1,2)*A(2,3)*A(3,1) &
+        + A(1,3)*A(2,1)*A(3,2) &
+        - A(3,1)*A(2,2)*A(1,3) &
+        - A(3,2)*A(2,3)*A(1,1) &
+        - A(3,3)*A(2,1)*A(1,2)
+
+  end subroutine mdet
+
+  !> 3x3 identity matrix.
+  subroutine identity3(iden)
+    real(dp), intent(out) :: iden(3,3)
+    integer :: i, j
+
+    do i = 1, 3
+      do j = 1, 3
+        if (i == j) then
+          iden(i,j) = ONE
+        else
+          iden(i,j) = ZERO
+        end if
+      end do
+    end do
+
+  end subroutine identity3
+
+end module uel_shape

--- a/src/element/uel_entry.f90
+++ b/src/element/uel_entry.f90
@@ -1,0 +1,133 @@
+! ==============================================================================
+! ABAQUS-callable entry points for the user element layer.
+!
+!   uel    dispatches on jtype to the element kernels (module uel_element)
+!   uvarm  transfers globalSdv entries onto the dummy mesh for visualization
+!
+! These must be EXTERNAL (non-module) procedures so ABAQUS can resolve them.
+! ==============================================================================
+
+subroutine uel(rhs, amatrx, svars, energy, ndofel, nrhs, nsvars, &
+               props, nprops, coords, mcrd, nnode, u, du, v, a, jtype, &
+               time, dtime, kstep, kinc, jelem, params, ndload, jdltyp, &
+               adlmag, predef, npredf, lflags, mlvarx, ddlmag, mdload, &
+               pnewdt, jprops, njprop, period)
+
+  use mod_constants, only: dp, ZERO
+  use uel_config, only: nIntPt
+  use uel_element, only: u3d8
+
+  implicit none
+
+  ! Variables passed into the UEL
+  integer, intent(in)  :: ndofel, nrhs, nsvars, nprops, mcrd, nnode, jtype
+  integer, intent(in)  :: kstep, kinc, jelem, ndload, npredf, mlvarx
+  integer, intent(in)  :: mdload, njprop
+  integer, intent(in)  :: jdltyp(mdload,1), lflags(4), jprops(njprop)
+
+  ! Variables defined here, passed back to ABAQUS
+  real(dp), intent(inout) :: rhs(mlvarx,1), amatrx(ndofel,ndofel)
+  real(dp), intent(inout) :: svars(nsvars), energy(8), pnewdt
+
+  real(dp), intent(in) :: props(nprops), coords(mcrd,nnode), u(ndofel)
+  real(dp), intent(in) :: du(mlvarx,1), v(ndofel), a(ndofel)
+  real(dp), intent(in) :: time(2), dtime, params(1), adlmag(mdload,1)
+  real(dp), intent(in) :: predef(2,npredf,nnode), ddlmag(mdload,1), period
+
+  integer :: nDim
+
+  !----------------------------------------------------------------------
+  ! Perform initial checks
+  !
+  ! Check the procedure type: static general (1,2) or coupled
+  ! displacement procedures (64,65,72,73) are supported, the element
+  ! itself being purely mechanical
+  select case (lflags(1))
+  case (1, 2, 64, 65, 72, 73)
+    ! all is good
+  case default
+    write(*,*) 'Abaqus does not have the right procedure'
+    write(*,*) 'go back and check the procedure type'
+    write(*,*) 'lflags(1)=', lflags(1)
+    call exit(1)
+  end select
+
+  ! Make sure Abaqus knows you are doing a large deformation problem
+  if (lflags(2) == 0) then
+    !
+    ! lflags(2)=0 -> small disp.
+    ! lflags(2)=1 -> large disp.
+    !
+    write(*,*) 'Abaqus thinks you are doing'
+    write(*,*) 'a small displacement analysis'
+    write(*,*) 'go in and set nlgeom=yes'
+    call exit(1)
+  end if
+
+  ! Check if it is a general step or a linear perturbation step
+  if (lflags(4) == 1) then
+    !
+    ! lflags(4)=0 -> general step
+    ! lflags(4)=1 -> linear perturbation step
+    !
+    write(*,*) 'Abaqus thinks you are doing'
+    write(*,*) 'a linear perturbation step'
+    call exit(1)
+  end if
+
+  ! Do nothing if a "dummy" step
+  if (dtime == ZERO) return
+  !
+  ! Done with initial checks
+  !----------------------------------------------------------------------
+
+  if (jtype == 3) then
+    !
+    ! This is a 3D analysis
+    !
+    nDim = 3
+    call u3d8(rhs, amatrx, svars, energy, ndofel, nrhs, nsvars, &
+              props, nprops, coords, mcrd, nnode, u, du, v, a, jtype, &
+              time, dtime, kstep, kinc, jelem, params, ndload, jdltyp, &
+              adlmag, predef, npredf, lflags, mlvarx, ddlmag, mdload, &
+              pnewdt, jprops, njprop, period, nDim, nIntPt)
+  else
+    !
+    ! We have a problem...
+    !
+    write(*,*) 'Element type not supported, jtype=', jtype
+    call exit(1)
+  end if
+  !
+  ! Done with this element; RHS and AMATRX are returned as output from
+  ! the element routine called above
+
+end subroutine uel
+
+
+subroutine uvarm(uvar, direct, t, time, dtime, cmname, orname, &
+                 nuvarm, noel, npt, layer, kspt, kstep, kinc, ndi, nshr, &
+                 coord, jmac, jmatyp, matlayo, laccfla)
+
+  ! This subroutine is used to transfer SDV's from the UEL onto the dummy
+  ! mesh for viewing. Note that an offset of ElemOffset is used between
+  ! the real mesh and the dummy mesh.
+
+  use uel_config, only: globalSdv, ElemOffset
+
+  implicit none
+
+  character*80 :: cmname, orname
+  integer :: nuvarm, noel, npt, layer, kspt, kstep, kinc, ndi, nshr
+  integer :: matlayo, laccfla
+  integer :: jmac(*), jmatyp(*)
+  double precision :: uvar(nuvarm), direct(3,3), t(3,3), time(2), dtime
+  double precision :: coord(*)
+
+  integer :: i1
+
+  do i1 = 1, nuvarm
+    uvar(i1) = globalSdv(noel-ElemOffset, npt, i1)
+  end do
+
+end subroutine uvarm

--- a/src/mod_continuum.f90
+++ b/src/mod_continuum.f90
@@ -20,7 +20,7 @@ module mod_continuum
   public :: pk2_anisofic, cmat_anisofic
 
   ! Jaumann rate
-  public :: set_jr
+  public :: set_jr, set_geometric
 
   ! Voigt indexing
   public :: indexx
@@ -333,6 +333,30 @@ contains
       end do
     end do
   end subroutine set_jr
+
+  !> Geometric (initial-stress) contribution for the UEL spatial tangent.
+  !>
+  !> The displacement-based UEL assembles Kuu = ∫ Gᵀ·A·G dv with
+  !>   a_ijkl = (1/J) F_jJ F_lL ∂P_iJ/∂F_kL = c_ijkl + δ_ik σ_jl,
+  !> i.e. the push-forward of the first elasticity tensor. The geometric term
+  !> δ_ik σ_jl is NOT the Jaumann correction set_jr builds for ABAQUS UMATs
+  !> (that one is its full symmetrization); a_ijkl has no minor symmetry,
+  !> which is why the element is declared Unsymm.
+  subroutine set_geometric(cgeo, sigma, unit2)
+    real(dp), intent(out) :: cgeo(3,3,3,3)
+    real(dp), intent(in)  :: sigma(3,3), unit2(3,3)
+    integer :: i, j, k, l
+
+    do i = 1, 3
+      do j = 1, 3
+        do k = 1, 3
+          do l = 1, 3
+            cgeo(i,j,k,l) = unit2(i,k) * sigma(j,l)
+          end do
+        end do
+      end do
+    end do
+  end subroutine set_geometric
 
   ! ============================================================================
   ! VOIGT INDEXING (ABAQUS INTERFACE)

--- a/src/umat_builder.f90
+++ b/src/umat_builder.f90
@@ -1,5 +1,18 @@
-!> @brief Composable UMAT builder — a single UMAT entry point that assembles
-!>        material behaviour from building blocks selected at runtime via PROPS.
+!> @brief Composable material builder — one constitutive core that assembles
+!>        material behaviour from building blocks selected at runtime via PROPS,
+!>        exposed through two thin interface wrappers:
+!>
+!>          umat(...)          ABAQUS *USER MATERIAL entry point. Adds the
+!>                             Jaumann-rate term and collapses to Voigt
+!>                             (STRESS/DDSDDE), as ABAQUS built-in elements
+!>                             require.
+!>          material_uel(...)  UEL-facing entry point (module mod_material).
+!>                             Returns the full Cauchy stress sigma(3,3) and
+!>                             the assembly tangent
+!>                               a_ijkl = c_ijkl + delta_ik sigma_jl
+!>                             (push-forward of dP/dF) that a displacement
+!>                             UEL needs for Kuu = int G^T A G dv. Note this
+!>                             geometric term is NOT the Jaumann correction.
 !>
 !> ============================================================================
 !> PROPS LAYOUT  (see PROPS_REFERENCE.md for full documentation)
@@ -25,27 +38,581 @@
 !>   STATEV(sdv_visco : +9*N_V-1) = hidden stress tensors    (if visco)
 !> ============================================================================
 
+module mod_material
+  implicit none
+
+contains
+
+  !> Constitutive core shared by the UMAT and UEL wrappers.
+  !>
+  !> Returns the total Cauchy stress and the BARE spatial elasticity tensor
+  !> (volumetric + isochoric, damage-softened, visco-augmented) WITHOUT any
+  !> rate-convention term — each wrapper adds its own (set_jr or set_geometric).
+  !>
+  !> istat: 0 = ok; 1 = inverted/degenerate element (det(F) <= 0), pnewdt has
+  !> been set to HALF and sigma/cspatial are zero — the caller should return
+  !> without touching its outputs so ABAQUS cuts the increment back.
+  subroutine material_core(sigma, cspatial, sse, istat, &
+                           statev, nstatev, props, nprops, dfgrd1, &
+                           time, dtime, predef, dpred, pnewdt, &
+                           noel, npt, kstep, kinc)
+
+    use mod_constants
+    use mod_tensor,       only: onem, push2, push4, pull2, pull4, matinv3d
+    use mod_kinematics,   only: distortion_gradient, cauchy_green, invariants, &
+                                 pseudo_invariants, stretch_tensors, rotation_tensor, &
+                                 projection_euler, projection_lagrange
+    use mod_continuum,    only: vol_energy, pk2_vol, sig_vol, met_vol, set_vol, &
+                                 pk2_isomatfic, sig_isomatfic, cmat_isomatfic, cs_isomatfic, &
+                                 pk2_iso, sig_iso, met_iso, set_iso, &
+                                 pk2_anisofic, cmat_anisofic
+    use mod_hyperelastic, only: sef_neo_hooke, sef_mooney_rivlin, sef_humphrey, sef_ogden
+    use mod_anisotropic,  only: fiber_direction, sef_aniso_hgo, sef_aniso_humphrey, &
+                                 sef_aniso_humphrey_act, sef_aniso_hgo_ai, &
+                                 sef_aniso_humphrey_ai
+    use mod_damage,       only: damage_sigmoid
+    use mod_viscosity,    only: visco_maxwell, MAX_VISCO_BRANCHES
+
+    implicit none
+
+    real(dp), intent(out)   :: sigma(3,3), cspatial(3,3,3,3)
+    double precision, intent(out)   :: sse
+    integer,  intent(out)   :: istat
+    integer,  intent(in)    :: nstatev, nprops
+    double precision, intent(in out) :: statev(nstatev)
+    double precision, intent(in)     :: props(nprops)
+    double precision, intent(in)     :: dfgrd1(3,3)
+    double precision, intent(in)     :: time(2), dtime
+    double precision, intent(in)     :: predef(1), dpred(1)
+    double precision, intent(in out) :: pnewdt
+    integer,  intent(in)    :: noel, npt, kstep, kinc
+
+    ! --- Configuration from PROPS header ---
+    real(dp) :: kbulk
+    integer  :: iso_type, aniso_type, n_fiber_fam, network_type, damage_type, n_visco
+    integer  :: ip  ! parameter index pointer
+
+    ! --- Identity and projection tensors ---
+    real(dp) :: unit2(3,3), unit4(3,3,3,3), unit4s(3,3,3,3)
+    real(dp) :: proje(3,3,3,3), projl(3,3,3,3)
+
+    ! --- Kinematics ---
+    real(dp) :: distgr(3,3), c(3,3), b(3,3), cbar(3,3), bbar(3,3)
+    real(dp) :: ubar(3,3), vbar(3,3)
+    real(dp) :: det, cbari1, cbari2
+
+    ! --- Volumetric ---
+    real(dp) :: ssev, pv, ppv
+    real(dp) :: pkvol(3,3), svol(3,3), cmvol(3,3,3,3), cvol(3,3,3,3)
+
+    ! --- Isochoric isotropic ---
+    real(dp) :: sseiso, diso(5)
+    real(dp) :: pkmatfic(3,3), sisomatfic(3,3)
+    real(dp) :: cmisomatfic(3,3,3,3), cisomatfic(3,3,3,3)
+    integer  :: n_ogden_terms
+    logical  :: iso_fic_active
+
+    ! --- Isochoric anisotropic ---
+    real(dp) :: sseaniso, daniso(4)
+    real(dp) :: pkmatficaniso(3,3), sanisomatfic(3,3)
+    real(dp) :: cmanisomatfic(3,3,3,3), canisomatfic(3,3,3,3)
+    real(dp) :: vorif(3), vd(3), st0(3,3)
+    real(dp) :: cbari4, lambda_fib, barlambda
+    real(dp) :: k1_fib, k2_fib, kdisp_fib, t0m_act, bdisp_fib
+    real(dp) :: sfic_aniso_ai(3,3), cfic_aniso_ai(3,3,3,3), w_aniso_ai
+    real(dp) :: finv(3,3)
+    integer  :: ifam, factor_aniso
+
+    ! --- Network ---
+    real(dp) :: phi_net
+    real(dp) :: snet(3,3), cnet(3,3,3,3)
+
+    ! --- Combined fictitious tensors ---
+    real(dp) :: pkfic(3,3), sfic(3,3), cmfic(3,3,3,3), cfic(3,3,3,3)
+
+    ! --- Isochoric projected ---
+    real(dp) :: pkiso(3,3), siso(3,3), cmiso(3,3,3,3), ciso(3,3,3,3)
+
+    ! --- Damage ---
+    real(dp) :: dmg, dmg_red, dmg_diff, sef0_hist, beta_d, psi_half
+    real(dp) :: pkiso0(3,3), siso0(3,3)   ! undamaged isochoric stress (for consistent tangent)
+    integer  :: di, dj, dk, dl
+
+    ! --- Viscosity ---
+    real(dp) :: vscprops(2*MAX_VISCO_BRANCHES)
+    real(dp) :: pk2_visc(3,3), cmat_visc(3,3,3,3)
+    real(dp) :: sigma_visc(3,3), cspatial_visc(3,3,3,3)
+    integer  :: sdv_offset_visco
+
+    ! --- Temporaries ---
+    integer :: i
+
+    ! --- Interface for external network subroutine ---
+    interface
+      subroutine network_contribution(network_type, props, ip, distgr, det, &
+                                      phi_net, snet, cnet, &
+                                      statev, nstatev, dtime, time, kstep, noel, &
+                                      damage_type, n_visco)
+        use mod_constants, only: dp
+        implicit none
+        integer,  intent(in)    :: network_type
+        double precision, intent(in) :: props(*)
+        integer,  intent(inout) :: ip
+        real(dp), intent(in)    :: distgr(3,3), det
+        real(dp), intent(out)   :: phi_net, snet(3,3), cnet(3,3,3,3)
+        double precision, intent(inout) :: statev(*)
+        integer,  intent(in)    :: nstatev, kstep, noel
+        double precision, intent(in) :: dtime, time(2)
+        integer,  intent(in)    :: damage_type, n_visco
+      end subroutine network_contribution
+    end interface
+
+    ! ============================================================================
+    ! READ CONFIGURATION FROM PROPS
+    ! ============================================================================
+    kbulk       = props(1)
+    iso_type    = nint(props(2))
+    aniso_type  = nint(props(3))
+    n_fiber_fam = nint(props(4))
+    network_type= nint(props(5))
+    damage_type = nint(props(6))
+    n_visco     = nint(props(7))
+    ip = 8  ! pointer to start of material parameters
+
+    ! ============================================================================
+    ! INITIALIZATIONS
+    ! ============================================================================
+    istat = 0
+    sse   = ZERO
+    call onem(unit2, unit4, unit4s)
+
+    ! Zero all working arrays
+    pkmatfic = ZERO; sisomatfic = ZERO
+    cmisomatfic = ZERO; cisomatfic = ZERO
+    pkmatficaniso = ZERO; sanisomatfic = ZERO
+    cmanisomatfic = ZERO; canisomatfic = ZERO
+    pkfic = ZERO; sfic = ZERO; cmfic = ZERO; cfic = ZERO
+    sigma = ZERO; cspatial = ZERO
+    sseiso = ZERO; diso = ZERO
+    sseaniso = ZERO; daniso = ZERO
+    snet = ZERO; cnet = ZERO
+
+    ! Initialize state variables on first increment
+    if (time(1) == ZERO .and. kstep == 1) then
+      statev(1) = ONE
+      if (damage_type > 0 .and. nstatev >= 3) then
+        statev(2) = ZERO  ! damage
+        statev(3) = ZERO  ! max SEF
+      end if
+      ! Explicitly zero the viscous hidden-stress tensors (9 per branch). ABAQUS
+      ! zero-inits STATEV, but being explicit guards restarts / re-used arrays.
+      if (n_visco > 0) then
+        sdv_offset_visco = 1
+        if (damage_type > 0) sdv_offset_visco = 3
+        do i = sdv_offset_visco + 1, min(sdv_offset_visco + 9*n_visco, nstatev)
+          statev(i) = ZERO
+        end do
+      end if
+    end if
+
+    ! ============================================================================
+    ! KINEMATICS
+    ! ============================================================================
+    call distortion_gradient(dfgrd1, distgr, det)
+
+    ! Guard against an inverted/degenerate element (det(F) <= 0). det**(-1/3) and
+    ! C^{-1} are undefined there (NaN); rather than poison the Newton iteration,
+    ! ask ABAQUS to cut the increment back and return.
+    if (det <= ZERO) then
+      pnewdt = HALF
+      istat = 1
+      return
+    end if
+
+    call cauchy_green(dfgrd1, c, b)
+    call cauchy_green(distgr, cbar, bbar)
+    call invariants(cbar, cbari1, cbari2)
+    call stretch_tensors(cbar, bbar, ubar, vbar)
+    call projection_euler(unit2, unit4s, proje)
+    call projection_lagrange(c, unit4, projl)
+
+    ! ============================================================================
+    ! CONSTITUTIVE RELATIONS
+    ! ============================================================================
+
+    ! --- Volumetric contribution (always present) ---
+    call vol_energy(kbulk, det, ssev, pv, ppv)
+
+    ! --- Isochoric isotropic contribution ---
+    select case (iso_type)
+    case (ISO_NEO_HOOKE)
+      call sef_neo_hooke(sseiso, diso, props(ip), cbari1, cbari2)
+      ip = ip + 1
+
+    case (ISO_MOONEY_RIVLIN)
+      call sef_mooney_rivlin(sseiso, diso, props(ip), props(ip+1), cbari1, cbari2)
+      ip = ip + 2
+
+    case (ISO_OGDEN)
+      n_ogden_terms = nint(props(ip))
+      ip = ip + 1
+      call sef_ogden(sseiso, diso, c, cbar, props(ip:ip+2*n_ogden_terms-1), n_ogden_terms)
+      ip = ip + 2*n_ogden_terms
+
+    case (ISO_HUMPHREY)
+      call sef_humphrey(sseiso, diso, props(ip), props(ip+1), cbari1, cbari2)
+      ip = ip + 2
+
+    case default
+      ! no isotropic contribution
+    end select
+
+    ! Whether the isotropic fictitious tensors must be built. An HGO fiber family
+    ! with dispersion (kdisp > 0) feeds the I1 channel back into diso, so this is
+    ! also switched on inside the fiber loop below.
+    iso_fic_active = (iso_type > 0)
+
+    ! Fictitious totals start at ZERO (already zeroed during initialization). The
+    ! isotropic contribution is added AFTER the fiber loop so that diso reflects
+    ! any HGO I1-I4 dispersion coupling fed back by sef_aniso_hgo.
+
+    ! --- Anisotropic contribution (fiber families) ---
+    do ifam = 1, n_fiber_fam
+      select case (aniso_type)
+      case (ANISO_HGO)
+        k1_fib    = props(ip)
+        k2_fib    = props(ip+1)
+        kdisp_fib = props(ip+2)
+        vorif     = props(ip+3:ip+5)
+        ip = ip + 6
+
+        call fiber_direction(vorif, distgr, st0, vd)
+        call pseudo_invariants(cbar, st0, det, cbari4, lambda_fib, barlambda)
+        call sef_aniso_hgo(sseaniso, daniso, diso, k1_fib, k2_fib, kdisp_fib, cbari4, cbari1)
+        iso_fic_active = .true.  ! HGO dispersion couples into the I1 (diso) channel
+
+      case (ANISO_HUMPHREY)
+        k1_fib = props(ip)
+        k2_fib = props(ip+1)
+        vorif  = props(ip+2:ip+4)
+        ip = ip + 5
+
+        call fiber_direction(vorif, distgr, st0, vd)
+        call pseudo_invariants(cbar, st0, det, cbari4, lambda_fib, barlambda)
+        call sef_aniso_humphrey(sseaniso, daniso, diso, k1_fib, k2_fib, cbari4, cbari1)
+
+      case (ANISO_HUMPHREY_ACT)
+        k1_fib = props(ip)
+        k2_fib = props(ip+1)
+        vorif  = props(ip+2:ip+4)
+        t0m_act = props(ip+5)
+        ip = ip + 6
+
+        call fiber_direction(vorif, distgr, st0, vd)
+        call pseudo_invariants(cbar, st0, det, cbari4, lambda_fib, barlambda)
+        call sef_aniso_humphrey(sseaniso, daniso, diso, k1_fib, k2_fib, cbari4, cbari1)
+        call sef_aniso_humphrey_act(sseaniso, daniso, cbari4, predef, dpred, t0m_act)
+
+      case (ANISO_HGO_AI)
+        k1_fib    = props(ip)
+        k2_fib    = props(ip+1)
+        bdisp_fib = props(ip+2)
+        factor_aniso = nint(props(ip+3))
+        vorif     = props(ip+4:ip+6)
+        ip = ip + 7
+
+        call sef_aniso_hgo_ai(sfic_aniso_ai, cfic_aniso_ai, w_aniso_ai, &
+                               distgr, det, k1_fib, k2_fib, bdisp_fib, factor_aniso, vorif)
+
+        ! AI aniso returns spatial sfic/cfic. Pull back to the material frame so the
+        ! fiber also enters pkfic/cmfic — needed for the viscous path (PK2/material
+        ! tangent) and to mirror the non-AI fiber (D1 fix). Then skip the daniso path.
+        call matinv3d(distgr, finv)
+        call pull2(pkmatficaniso, sfic_aniso_ai, finv, det)
+        call pull4(cmanisomatfic, cfic_aniso_ai, finv, det)
+        pkfic = pkfic + pkmatficaniso
+        sfic  = sfic  + sfic_aniso_ai
+        cmfic = cmfic + cmanisomatfic
+        cfic  = cfic  + cfic_aniso_ai
+        cycle
+
+      case (ANISO_HUMPHREY_AI)
+        k1_fib    = props(ip)
+        k2_fib    = props(ip+1)
+        bdisp_fib = props(ip+2)
+        factor_aniso = nint(props(ip+3))
+        vorif     = props(ip+4:ip+6)
+        ip = ip + 7
+
+        call sef_aniso_humphrey_ai(sfic_aniso_ai, cfic_aniso_ai, w_aniso_ai, &
+                                    distgr, det, k1_fib, k2_fib, bdisp_fib, factor_aniso, vorif)
+
+        ! Pull back to the material frame (D1 fix — see ANISO_HGO_AI above).
+        call matinv3d(distgr, finv)
+        call pull2(pkmatficaniso, sfic_aniso_ai, finv, det)
+        call pull4(cmanisomatfic, cfic_aniso_ai, finv, det)
+        pkfic = pkfic + pkmatficaniso
+        sfic  = sfic  + sfic_aniso_ai
+        cmfic = cmfic + cmanisomatfic
+        cfic  = cfic  + cfic_aniso_ai
+        cycle
+
+      case default
+        cycle
+      end select
+
+      ! Anisotropic fictitious stress and stiffness
+      call pk2_anisofic(pkmatficaniso, daniso, st0)
+      call push2(sanisomatfic, pkmatficaniso, distgr, det)
+      call cmat_anisofic(cmanisomatfic, st0, daniso, unit2, det)
+      call push4(canisomatfic, cmanisomatfic, distgr, det)
+
+      ! Accumulate into total fictitious tensors
+      pkfic = pkfic + pkmatficaniso
+      sfic  = sfic  + sanisomatfic
+      cmfic = cmfic + cmanisomatfic
+      cfic  = cfic  + canisomatfic
+    end do
+
+    ! --- Isochoric isotropic fictitious tensors ---
+    ! Built AFTER the fiber loop so diso includes any HGO I1-I4 dispersion coupling
+    ! fed back by sef_aniso_hgo, then added to the (so far anisotropic-only) totals.
+    if (iso_fic_active) then
+      call pk2_isomatfic(pkmatfic, diso, cbar, cbari1, unit2)
+      call sig_isomatfic(sisomatfic, pkmatfic, distgr, det)
+      call cmat_isomatfic(cmisomatfic, cbar, cbari1, cbari2, diso, unit2, unit4, det)
+      call cs_isomatfic(cisomatfic, cmisomatfic, distgr, det)
+      pkfic = pkfic + pkmatfic
+      sfic  = sfic  + sisomatfic
+      cmfic = cmfic + cmisomatfic
+      cfic  = cfic  + cisomatfic
+    end if
+
+    ! --- Network contribution ---
+    ! Compute the network now (this advances the PROPS pointer past the network
+    ! params), but DEFER the matrix/network blend until AFTER damage, so damage
+    ! scales only the matrix — consistent with the damage criterion, which uses
+    ! the matrix energy and excludes the network (D3). Network models require
+    ! quadrature data loaded via UEXTERNALDB; snet/cnet are fictitious spatial.
+    if (network_type > 0) then
+      call network_contribution(network_type, props, ip, distgr, det, &
+                                phi_net, snet, cnet, &
+                                statev, nstatev, dtime, time, kstep, noel, &
+                                damage_type, n_visco)
+    else
+      phi_net = ZERO
+    end if
+
+    ! --- Damage modification (matrix only; applied BEFORE the network blend) ---
+    if (damage_type == DMG_SIGMOID) then
+      beta_d   = props(ip)
+      psi_half = props(ip+1)
+      ip = ip + 2
+
+      dmg       = statev(2)
+      sef0_hist = statev(3)
+
+      call damage_sigmoid(sseiso + sseaniso, sef0_hist, dmg, dmg_red, dmg_diff, beta_d, psi_half)
+
+      statev(2) = dmg
+      statev(3) = sef0_hist
+
+      ! Capture the UNDAMAGED matrix isochoric stresses before scaling. They drive
+      ! the consistent-tangent softening term d'(W)*S0 (x) S0, added after assembly.
+      call pk2_iso(pkiso0, pkfic, projl, det)
+      call sig_iso(siso0, sfic, proje)
+
+      ! Secant scaling of the MATRIX (the network, blended below, is left undamaged).
+      pkfic = dmg_red * pkfic
+      sfic  = dmg_red * sfic
+      cmfic = dmg_red * cmfic
+      cfic  = dmg_red * cfic
+
+      ! Scale strain energy for consistency with damaged stress
+      sseiso   = dmg_red * sseiso
+      sseaniso = dmg_red * sseaniso
+    end if
+
+    ! --- Blend the (now damaged) matrix with the pristine network ---
+    ! total = (1-PHI)*matrix + PHI*network; the network is NOT damaged here and
+    ! (in the viscous branch below) is NOT relaxed.
+    if (network_type > 0) then
+      sfic  = (ONE - phi_net) * sfic  + phi_net * snet
+      cfic  = (ONE - phi_net) * cfic  + phi_net * cnet
+      pkfic = (ONE - phi_net) * pkfic   ! network has no PK2 part
+    end if
+
+    ! ============================================================================
+    ! STRESS MEASURES (elastic, no viscosity yet)
+    ! ============================================================================
+
+    ! --- Volumetric ---
+    call pk2_vol(pkvol, pv, c, det)
+    call sig_vol(svol, pv, unit2)
+
+    ! --- Isochoric (projected) ---
+    call pk2_iso(pkiso, pkfic, projl, det)
+    call sig_iso(siso, sfic, proje)
+
+    ! --- Total elastic Cauchy stress ---
+    sigma = svol + siso
+
+    ! ============================================================================
+    ! ELASTICITY TENSORS (elastic, no rate-convention term)
+    ! ============================================================================
+
+    ! --- Material elasticity ---
+    call met_vol(cmvol, c, pv, ppv, det)
+    call met_iso(cmiso, cmfic, projl, pkiso, pkfic, c, unit2, det)
+
+    ! --- Spatial elasticity ---
+    call set_vol(cvol, pv, ppv, unit2, unit4s)
+    call set_iso(ciso, cfic, proje, siso, sfic, unit2)
+
+    ! --- Consistent damage softening term ---
+    ! sigma = sigma_vol + d_red(W)*sigma_iso0, so the tangent gains
+    !   material: C_m += d'(W) * S_iso0 (x) S_iso0
+    !   spatial:  c   += d'(W) * J * sigma_iso0 (x) sigma_iso0
+    ! (dmg_diff = d(d_red)/dW < 0; it is ZERO unless damage is actively growing).
+    if (damage_type == DMG_SIGMOID .and. dmg_diff /= ZERO) then
+      do di = 1, 3
+        do dj = 1, 3
+          do dk = 1, 3
+            do dl = 1, 3
+              cmiso(di,dj,dk,dl) = cmiso(di,dj,dk,dl) &
+                                 + dmg_diff * pkiso0(di,dj) * pkiso0(dk,dl)
+              ciso(di,dj,dk,dl)  = ciso(di,dj,dk,dl) &
+                                 + dmg_diff * det * siso0(di,dj) * siso0(dk,dl)
+            end do
+          end do
+        end do
+      end do
+    end if
+
+    cspatial = cvol + ciso
+
+    ! ============================================================================
+    ! VISCOUS CONTRIBUTION (optional)
+    ! ============================================================================
+    ! The viscous model operates on the material frame (PK2 + material tangent).
+    ! It modifies PK2 by adding viscous overstress and scales the isochoric
+    ! material tangent. We then push-forward the result to the spatial frame.
+    ! Note: viscosity applies to the continuum (matrix) part only. If a network
+    ! model is active, the network spatial contribution is added back afterwards.
+    if (n_visco > 0) then
+      vscprops = ZERO
+      do i = 1, min(n_visco, MAX_VISCO_BRANCHES)
+        vscprops(2*i-1) = props(ip)      ! tau
+        vscprops(2*i)   = props(ip+1)    ! theta
+        ip = ip + 2
+      end do
+
+      ! Offset: after det (1) + damage vars (2 if active)
+      sdv_offset_visco = 1
+      if (damage_type > 0) sdv_offset_visco = 3
+
+      ! visco_maxwell returns modified PK2 (pk2_visc) and material tangent (cmat_visc)
+      call visco_maxwell(pk2_visc, cmat_visc, &
+                         min(n_visco, MAX_VISCO_BRANCHES), pkvol, pkiso, &
+                         cmvol, cmiso, dtime, vscprops, statev, sdv_offset_visco)
+
+      ! Push-forward to get spatial quantities
+      call push2(sigma_visc, pk2_visc, dfgrd1, det)
+      call push4(cspatial_visc, cmat_visc, dfgrd1, det)
+
+      ! Override elastic results with viscous-augmented versions
+      sigma    = sigma_visc
+      cspatial = cspatial_visc
+
+      ! Re-add the network (viscosity relaxes the matrix only; the network is
+      ! pristine — NOT relaxed). Use snet/cnet directly, NOT the blended sfic/cfic,
+      ! so the (1-phi)*matrix + phi*network blend is not double-counted (D2).
+      if (network_type > 0) then
+        call sig_iso(siso, snet, proje)
+        call set_iso(ciso, cnet, proje, siso, snet, unit2)
+        sigma    = sigma    + phi_net * siso
+        cspatial = cspatial + phi_net * ciso
+      end if
+    end if
+
+    ! ============================================================================
+    ! STRAIN ENERGY
+    ! ============================================================================
+    sse = ssev + sseiso + sseaniso
+
+    ! ============================================================================
+    ! STATE VARIABLES
+    ! ============================================================================
+    statev(1) = det
+
+  end subroutine material_core
+
+
+  !> UEL-facing entry point: full Cauchy stress and the displacement-UEL
+  !> assembly tangent  a_ijkl = c_ijkl + delta_ik sigma_jl  (push-forward of
+  !> dP/dF). Use this from user elements that build Kuu = int G^T A G dv;
+  !> a has no minor symmetry, so declare the element Unsymm.
+  subroutine material_uel(sigma, atangent, sse, &
+                          statev, nstatev, props, nprops, dfgrd1, &
+                          time, dtime, predef, dpred, pnewdt, &
+                          noel, npt, kstep, kinc)
+
+    use mod_constants, only: dp, ZERO
+    use mod_tensor,    only: onem
+    use mod_continuum, only: set_geometric
+
+    implicit none
+
+    real(dp), intent(out)   :: sigma(3,3), atangent(3,3,3,3)
+    double precision, intent(out)   :: sse
+    integer,  intent(in)    :: nstatev, nprops
+    double precision, intent(in out) :: statev(nstatev)
+    double precision, intent(in)     :: props(nprops)
+    double precision, intent(in)     :: dfgrd1(3,3)
+    double precision, intent(in)     :: time(2), dtime
+    double precision, intent(in)     :: predef(1), dpred(1)
+    double precision, intent(in out) :: pnewdt
+    integer,  intent(in)    :: noel, npt, kstep, kinc
+
+    real(dp) :: cspatial(3,3,3,3), cgeo(3,3,3,3)
+    real(dp) :: unit2(3,3), unit4(3,3,3,3), unit4s(3,3,3,3)
+    integer  :: istat
+
+    call material_core(sigma, cspatial, sse, istat, &
+                       statev, nstatev, props, nprops, dfgrd1, &
+                       time, dtime, predef, dpred, pnewdt, &
+                       noel, npt, kstep, kinc)
+
+    if (istat /= 0) then
+      ! Inverted element: pnewdt already cut; hand back zeros so the element
+      ! assembles cleanly while ABAQUS abandons the increment.
+      atangent = ZERO
+      return
+    end if
+
+    call onem(unit2, unit4, unit4s)
+    call set_geometric(cgeo, sigma, unit2)
+    atangent = cspatial + cgeo
+
+  end subroutine material_uel
+
+end module mod_material
+
+
+! ==============================================================================
+! ABAQUS *USER MATERIAL entry point (built-in elements).
+! Thin wrapper: constitutive core + Jaumann rate term + Voigt indexing.
+! ==============================================================================
 subroutine umat(stress, statev, ddsdde, sse, spd, scd, &
      rpl, ddsddt, drplde, drpldt, &
      stran, dstran, time, dtime, temp, dtemp, predef, dpred, cmname, &
      ndi, nshr, ntens, nstatev, props, nprops, coords, drot, pnewdt, &
      celent, dfgrd0, dfgrd1, noel, npt, layer, kspt, kstep, kinc)
 
-  use mod_constants
-  use mod_tensor,       only: onem, push2, push4, pull2, pull4, matinv3d
-  use mod_kinematics,   only: distortion_gradient, cauchy_green, invariants, &
-                               pseudo_invariants, stretch_tensors, rotation_tensor, &
-                               projection_euler, projection_lagrange
-  use mod_continuum,    only: vol_energy, pk2_vol, sig_vol, met_vol, set_vol, &
-                               pk2_isomatfic, sig_isomatfic, cmat_isomatfic, cs_isomatfic, &
-                               pk2_iso, sig_iso, met_iso, set_iso, &
-                               pk2_anisofic, cmat_anisofic, set_jr, indexx
-  use mod_hyperelastic, only: sef_neo_hooke, sef_mooney_rivlin, sef_humphrey, sef_ogden
-  use mod_anisotropic,  only: fiber_direction, sef_aniso_hgo, sef_aniso_humphrey, &
-                               sef_aniso_humphrey_act, sef_aniso_hgo_ai, &
-                               sef_aniso_humphrey_ai
-  use mod_damage,       only: damage_sigmoid
-  use mod_viscosity,    only: visco_maxwell, MAX_VISCO_BRANCHES
+  use mod_constants, only: dp
+  use mod_tensor,    only: onem
+  use mod_continuum, only: set_jr, indexx
+  use mod_material,  only: material_core
 
   implicit none
 
@@ -73,474 +640,26 @@ subroutine umat(stress, statev, ddsdde, sse, spd, scd, &
   double precision, intent(in out) :: pnewdt, celent
   double precision, intent(in out) :: dfgrd0(3,3), dfgrd1(3,3)
 
-  ! --- Configuration from PROPS header ---
-  real(dp) :: kbulk
-  integer  :: iso_type, aniso_type, n_fiber_fam, network_type, damage_type, n_visco
-  integer  :: ip  ! parameter index pointer
-
-  ! --- Identity and projection tensors ---
+  real(dp) :: sigma(3,3), cspatial(3,3,3,3), ddsigdde(3,3,3,3), cjr(3,3,3,3)
   real(dp) :: unit2(3,3), unit4(3,3,3,3), unit4s(3,3,3,3)
-  real(dp) :: proje(3,3,3,3), projl(3,3,3,3)
+  integer  :: istat
 
-  ! --- Kinematics ---
-  real(dp) :: distgr(3,3), c(3,3), b(3,3), cbar(3,3), bbar(3,3)
-  real(dp) :: ubar(3,3), vbar(3,3)
-  real(dp) :: det, cbari1, cbari2
+  call material_core(sigma, cspatial, sse, istat, &
+                     statev, nstatev, props, nprops, dfgrd1, &
+                     time, dtime, predef, dpred, pnewdt, &
+                     noel, npt, kstep, kinc)
 
-  ! --- Volumetric ---
-  real(dp) :: ssev, pv, ppv
-  real(dp) :: pkvol(3,3), svol(3,3), cmvol(3,3,3,3), cvol(3,3,3,3)
+  ! Inverted element: pnewdt already cut; leave stress/ddsdde untouched so
+  ! ABAQUS abandons the increment (matches the pre-refactor behavior).
+  if (istat /= 0) return
 
-  ! --- Isochoric isotropic ---
-  real(dp) :: sseiso, diso(5)
-  real(dp) :: pkmatfic(3,3), sisomatfic(3,3)
-  real(dp) :: cmisomatfic(3,3,3,3), cisomatfic(3,3,3,3)
-  integer  :: n_ogden_terms
-  logical  :: iso_fic_active
-
-  ! --- Isochoric anisotropic ---
-  real(dp) :: sseaniso, daniso(4)
-  real(dp) :: pkmatficaniso(3,3), sanisomatfic(3,3)
-  real(dp) :: cmanisomatfic(3,3,3,3), canisomatfic(3,3,3,3)
-  real(dp) :: vorif(3), vd(3), st0(3,3)
-  real(dp) :: cbari4, lambda_fib, barlambda
-  real(dp) :: k1_fib, k2_fib, kdisp_fib, t0m_act, bdisp_fib
-  real(dp) :: sfic_aniso_ai(3,3), cfic_aniso_ai(3,3,3,3), w_aniso_ai
-  real(dp) :: finv(3,3)
-  integer  :: ifam, factor_aniso
-
-  ! --- Network ---
-  real(dp) :: phi_net, net_density, b_orient, efi, pp_naff
-  real(dp) :: filprops(8)
-  real(dp) :: snet(3,3), cnet(3,3,3,3)
-
-  ! --- Combined fictitious tensors ---
-  real(dp) :: pkfic(3,3), sfic(3,3), cmfic(3,3,3,3), cfic(3,3,3,3)
-
-  ! --- Isochoric projected ---
-  real(dp) :: pkiso(3,3), siso(3,3), cmiso(3,3,3,3), ciso(3,3,3,3)
-
-  ! --- Total ---
-  real(dp) :: sigma(3,3), ddsigdde(3,3,3,3)
-  real(dp) :: cjr(3,3,3,3)
-
-  ! --- Damage ---
-  real(dp) :: dmg, dmg_red, dmg_diff, sef0_hist, beta_d, psi_half
-  real(dp) :: pkiso0(3,3), siso0(3,3)   ! undamaged isochoric stress (for consistent tangent)
-  integer  :: di, dj, dk, dl
-
-  ! --- Viscosity ---
-  real(dp) :: vscprops(2*MAX_VISCO_BRANCHES)
-  real(dp) :: pk2_visc(3,3), cmat_visc(3,3,3,3)
-  real(dp) :: sigma_visc(3,3), cspatial_visc(3,3,3,3)
-  integer  :: sdv_offset_visco
-
-  ! --- Temporaries ---
-  integer :: i
-
-  ! --- Interface for external network subroutine ---
-  interface
-    subroutine network_contribution(network_type, props, ip, distgr, det, &
-                                    phi_net, snet, cnet, &
-                                    statev, nstatev, dtime, time, kstep, noel, &
-                                    damage_type, n_visco)
-      use mod_constants, only: dp
-      implicit none
-      integer,  intent(in)    :: network_type
-      double precision, intent(in) :: props(*)
-      integer,  intent(inout) :: ip
-      real(dp), intent(in)    :: distgr(3,3), det
-      real(dp), intent(out)   :: phi_net, snet(3,3), cnet(3,3,3,3)
-      double precision, intent(inout) :: statev(*)
-      integer,  intent(in)    :: nstatev, kstep, noel
-      double precision, intent(in) :: dtime, time(2)
-      integer,  intent(in)    :: damage_type, n_visco
-    end subroutine network_contribution
-  end interface
-
-  ! ============================================================================
-  ! READ CONFIGURATION FROM PROPS
-  ! ============================================================================
-  kbulk       = props(1)
-  iso_type    = nint(props(2))
-  aniso_type  = nint(props(3))
-  n_fiber_fam = nint(props(4))
-  network_type= nint(props(5))
-  damage_type = nint(props(6))
-  n_visco     = nint(props(7))
-  ip = 8  ! pointer to start of material parameters
-
-  ! ============================================================================
-  ! INITIALIZATIONS
-  ! ============================================================================
+  ! Jaumann rate correction with the TOTAL Cauchy stress (ABAQUS UMAT
+  ! material Jacobian convention), then collapse to Voigt.
   call onem(unit2, unit4, unit4s)
-
-  ! Zero all working arrays
-  pkmatfic = ZERO; sisomatfic = ZERO
-  cmisomatfic = ZERO; cisomatfic = ZERO
-  pkmatficaniso = ZERO; sanisomatfic = ZERO
-  cmanisomatfic = ZERO; canisomatfic = ZERO
-  pkfic = ZERO; sfic = ZERO; cmfic = ZERO; cfic = ZERO
-  sigma = ZERO; ddsigdde = ZERO
-  sseiso = ZERO; diso = ZERO
-  sseaniso = ZERO; daniso = ZERO
-  snet = ZERO; cnet = ZERO
-
-  ! Initialize state variables on first increment
-  if (time(1) == ZERO .and. kstep == 1) then
-    statev(1) = ONE
-    if (damage_type > 0 .and. nstatev >= 3) then
-      statev(2) = ZERO  ! damage
-      statev(3) = ZERO  ! max SEF
-    end if
-    ! Explicitly zero the viscous hidden-stress tensors (9 per branch). ABAQUS
-    ! zero-inits STATEV, but being explicit guards restarts / re-used arrays.
-    if (n_visco > 0) then
-      sdv_offset_visco = 1
-      if (damage_type > 0) sdv_offset_visco = 3
-      do i = sdv_offset_visco + 1, min(sdv_offset_visco + 9*n_visco, nstatev)
-        statev(i) = ZERO
-      end do
-    end if
-  end if
-
-  ! ============================================================================
-  ! KINEMATICS
-  ! ============================================================================
-  call distortion_gradient(dfgrd1, distgr, det)
-
-  ! Guard against an inverted/degenerate element (det(F) <= 0). det**(-1/3) and
-  ! C^{-1} are undefined there (NaN); rather than poison the Newton iteration,
-  ! ask ABAQUS to cut the increment back and return.
-  if (det <= ZERO) then
-    pnewdt = HALF
-    return
-  end if
-
-  call cauchy_green(dfgrd1, c, b)
-  call cauchy_green(distgr, cbar, bbar)
-  call invariants(cbar, cbari1, cbari2)
-  call stretch_tensors(cbar, bbar, ubar, vbar)
-  call projection_euler(unit2, unit4s, proje)
-  call projection_lagrange(c, unit4, projl)
-
-  ! ============================================================================
-  ! CONSTITUTIVE RELATIONS
-  ! ============================================================================
-
-  ! --- Volumetric contribution (always present) ---
-  call vol_energy(kbulk, det, ssev, pv, ppv)
-
-  ! --- Isochoric isotropic contribution ---
-  select case (iso_type)
-  case (ISO_NEO_HOOKE)
-    call sef_neo_hooke(sseiso, diso, props(ip), cbari1, cbari2)
-    ip = ip + 1
-
-  case (ISO_MOONEY_RIVLIN)
-    call sef_mooney_rivlin(sseiso, diso, props(ip), props(ip+1), cbari1, cbari2)
-    ip = ip + 2
-
-  case (ISO_OGDEN)
-    n_ogden_terms = nint(props(ip))
-    ip = ip + 1
-    call sef_ogden(sseiso, diso, c, cbar, props(ip:ip+2*n_ogden_terms-1), n_ogden_terms)
-    ip = ip + 2*n_ogden_terms
-
-  case (ISO_HUMPHREY)
-    call sef_humphrey(sseiso, diso, props(ip), props(ip+1), cbari1, cbari2)
-    ip = ip + 2
-
-  case default
-    ! no isotropic contribution
-  end select
-
-  ! Whether the isotropic fictitious tensors must be built. An HGO fiber family
-  ! with dispersion (kdisp > 0) feeds the I1 channel back into diso, so this is
-  ! also switched on inside the fiber loop below.
-  iso_fic_active = (iso_type > 0)
-
-  ! Fictitious totals start at ZERO (already zeroed during initialization). The
-  ! isotropic contribution is added AFTER the fiber loop so that diso reflects
-  ! any HGO I1-I4 dispersion coupling fed back by sef_aniso_hgo.
-
-  ! --- Anisotropic contribution (fiber families) ---
-  do ifam = 1, n_fiber_fam
-    select case (aniso_type)
-    case (ANISO_HGO)
-      k1_fib    = props(ip)
-      k2_fib    = props(ip+1)
-      kdisp_fib = props(ip+2)
-      vorif     = props(ip+3:ip+5)
-      ip = ip + 6
-
-      call fiber_direction(vorif, distgr, st0, vd)
-      call pseudo_invariants(cbar, st0, det, cbari4, lambda_fib, barlambda)
-      call sef_aniso_hgo(sseaniso, daniso, diso, k1_fib, k2_fib, kdisp_fib, cbari4, cbari1)
-      iso_fic_active = .true.  ! HGO dispersion couples into the I1 (diso) channel
-
-    case (ANISO_HUMPHREY)
-      k1_fib = props(ip)
-      k2_fib = props(ip+1)
-      vorif  = props(ip+2:ip+4)
-      ip = ip + 5
-
-      call fiber_direction(vorif, distgr, st0, vd)
-      call pseudo_invariants(cbar, st0, det, cbari4, lambda_fib, barlambda)
-      call sef_aniso_humphrey(sseaniso, daniso, diso, k1_fib, k2_fib, cbari4, cbari1)
-
-    case (ANISO_HUMPHREY_ACT)
-      k1_fib = props(ip)
-      k2_fib = props(ip+1)
-      vorif  = props(ip+2:ip+4)
-      t0m_act = props(ip+5)
-      ip = ip + 6
-
-      call fiber_direction(vorif, distgr, st0, vd)
-      call pseudo_invariants(cbar, st0, det, cbari4, lambda_fib, barlambda)
-      call sef_aniso_humphrey(sseaniso, daniso, diso, k1_fib, k2_fib, cbari4, cbari1)
-      call sef_aniso_humphrey_act(sseaniso, daniso, cbari4, predef, dpred, t0m_act)
-
-    case (ANISO_HGO_AI)
-      k1_fib    = props(ip)
-      k2_fib    = props(ip+1)
-      bdisp_fib = props(ip+2)
-      factor_aniso = nint(props(ip+3))
-      vorif     = props(ip+4:ip+6)
-      ip = ip + 7
-
-      call sef_aniso_hgo_ai(sfic_aniso_ai, cfic_aniso_ai, w_aniso_ai, &
-                             distgr, det, k1_fib, k2_fib, bdisp_fib, factor_aniso, vorif)
-
-      ! AI aniso returns spatial sfic/cfic. Pull back to the material frame so the
-      ! fiber also enters pkfic/cmfic — needed for the viscous path (PK2/material
-      ! tangent) and to mirror the non-AI fiber (D1 fix). Then skip the daniso path.
-      call matinv3d(distgr, finv)
-      call pull2(pkmatficaniso, sfic_aniso_ai, finv, det)
-      call pull4(cmanisomatfic, cfic_aniso_ai, finv, det)
-      pkfic = pkfic + pkmatficaniso
-      sfic  = sfic  + sfic_aniso_ai
-      cmfic = cmfic + cmanisomatfic
-      cfic  = cfic  + cfic_aniso_ai
-      cycle
-
-    case (ANISO_HUMPHREY_AI)
-      k1_fib    = props(ip)
-      k2_fib    = props(ip+1)
-      bdisp_fib = props(ip+2)
-      factor_aniso = nint(props(ip+3))
-      vorif     = props(ip+4:ip+6)
-      ip = ip + 7
-
-      call sef_aniso_humphrey_ai(sfic_aniso_ai, cfic_aniso_ai, w_aniso_ai, &
-                                  distgr, det, k1_fib, k2_fib, bdisp_fib, factor_aniso, vorif)
-
-      ! Pull back to the material frame (D1 fix — see ANISO_HGO_AI above).
-      call matinv3d(distgr, finv)
-      call pull2(pkmatficaniso, sfic_aniso_ai, finv, det)
-      call pull4(cmanisomatfic, cfic_aniso_ai, finv, det)
-      pkfic = pkfic + pkmatficaniso
-      sfic  = sfic  + sfic_aniso_ai
-      cmfic = cmfic + cmanisomatfic
-      cfic  = cfic  + cfic_aniso_ai
-      cycle
-
-    case default
-      cycle
-    end select
-
-    ! Anisotropic fictitious stress and stiffness
-    call pk2_anisofic(pkmatficaniso, daniso, st0)
-    call push2(sanisomatfic, pkmatficaniso, distgr, det)
-    call cmat_anisofic(cmanisomatfic, st0, daniso, unit2, det)
-    call push4(canisomatfic, cmanisomatfic, distgr, det)
-
-    ! Accumulate into total fictitious tensors
-    pkfic = pkfic + pkmatficaniso
-    sfic  = sfic  + sanisomatfic
-    cmfic = cmfic + cmanisomatfic
-    cfic  = cfic  + canisomatfic
-  end do
-
-  ! --- Isochoric isotropic fictitious tensors ---
-  ! Built AFTER the fiber loop so diso includes any HGO I1-I4 dispersion coupling
-  ! fed back by sef_aniso_hgo, then added to the (so far anisotropic-only) totals.
-  if (iso_fic_active) then
-    call pk2_isomatfic(pkmatfic, diso, cbar, cbari1, unit2)
-    call sig_isomatfic(sisomatfic, pkmatfic, distgr, det)
-    call cmat_isomatfic(cmisomatfic, cbar, cbari1, cbari2, diso, unit2, unit4, det)
-    call cs_isomatfic(cisomatfic, cmisomatfic, distgr, det)
-    pkfic = pkfic + pkmatfic
-    sfic  = sfic  + sisomatfic
-    cmfic = cmfic + cmisomatfic
-    cfic  = cfic  + cisomatfic
-  end if
-
-  ! --- Network contribution ---
-  ! Compute the network now (this advances the PROPS pointer past the network
-  ! params), but DEFER the matrix/network blend until AFTER damage, so damage
-  ! scales only the matrix — consistent with the damage criterion, which uses
-  ! the matrix energy and excludes the network (D3). Network models require
-  ! quadrature data loaded via UEXTERNALDB; snet/cnet are fictitious spatial.
-  if (network_type > 0) then
-    call network_contribution(network_type, props, ip, distgr, det, &
-                              phi_net, snet, cnet, &
-                              statev, nstatev, dtime, time, kstep, noel, &
-                              damage_type, n_visco)
-  else
-    phi_net = ZERO
-  end if
-
-  ! --- Damage modification (matrix only; applied BEFORE the network blend) ---
-  if (damage_type == DMG_SIGMOID) then
-    beta_d   = props(ip)
-    psi_half = props(ip+1)
-    ip = ip + 2
-
-    dmg       = statev(2)
-    sef0_hist = statev(3)
-
-    call damage_sigmoid(sseiso + sseaniso, sef0_hist, dmg, dmg_red, dmg_diff, beta_d, psi_half)
-
-    statev(2) = dmg
-    statev(3) = sef0_hist
-
-    ! Capture the UNDAMAGED matrix isochoric stresses before scaling. They drive
-    ! the consistent-tangent softening term d'(W)*S0 (x) S0, added after assembly.
-    call pk2_iso(pkiso0, pkfic, projl, det)
-    call sig_iso(siso0, sfic, proje)
-
-    ! Secant scaling of the MATRIX (the network, blended below, is left undamaged).
-    pkfic = dmg_red * pkfic
-    sfic  = dmg_red * sfic
-    cmfic = dmg_red * cmfic
-    cfic  = dmg_red * cfic
-
-    ! Scale strain energy for consistency with damaged stress
-    sseiso   = dmg_red * sseiso
-    sseaniso = dmg_red * sseaniso
-  end if
-
-  ! --- Blend the (now damaged) matrix with the pristine network ---
-  ! total = (1-PHI)*matrix + PHI*network; the network is NOT damaged here and
-  ! (in the viscous branch below) is NOT relaxed.
-  if (network_type > 0) then
-    sfic  = (ONE - phi_net) * sfic  + phi_net * snet
-    cfic  = (ONE - phi_net) * cfic  + phi_net * cnet
-    pkfic = (ONE - phi_net) * pkfic   ! network has no PK2 part
-  end if
-
-  ! ============================================================================
-  ! STRESS MEASURES (elastic, no viscosity yet)
-  ! ============================================================================
-
-  ! --- Volumetric ---
-  call pk2_vol(pkvol, pv, c, det)
-  call sig_vol(svol, pv, unit2)
-
-  ! --- Isochoric (projected) ---
-  call pk2_iso(pkiso, pkfic, projl, det)
-  call sig_iso(siso, sfic, proje)
-
-  ! --- Total elastic Cauchy stress ---
-  sigma = svol + siso
-
-  ! ============================================================================
-  ! ELASTICITY TENSORS (elastic)
-  ! ============================================================================
-
-  ! --- Material elasticity ---
-  call met_vol(cmvol, c, pv, ppv, det)
-  call met_iso(cmiso, cmfic, projl, pkiso, pkfic, c, unit2, det)
-
-  ! --- Spatial elasticity ---
-  call set_vol(cvol, pv, ppv, unit2, unit4s)
-  call set_iso(ciso, cfic, proje, siso, sfic, unit2)
-
-  ! --- Consistent damage softening term ---
-  ! sigma = sigma_vol + d_red(W)*sigma_iso0, so the tangent gains
-  !   material: C_m += d'(W) * S_iso0 (x) S_iso0
-  !   spatial:  c   += d'(W) * J * sigma_iso0 (x) sigma_iso0
-  ! (dmg_diff = d(d_red)/dW < 0; it is ZERO unless damage is actively growing).
-  if (damage_type == DMG_SIGMOID .and. dmg_diff /= ZERO) then
-    do di = 1, 3
-      do dj = 1, 3
-        do dk = 1, 3
-          do dl = 1, 3
-            cmiso(di,dj,dk,dl) = cmiso(di,dj,dk,dl) &
-                               + dmg_diff * pkiso0(di,dj) * pkiso0(dk,dl)
-            ciso(di,dj,dk,dl)  = ciso(di,dj,dk,dl) &
-                               + dmg_diff * det * siso0(di,dj) * siso0(dk,dl)
-          end do
-        end do
-      end do
-    end do
-  end if
-
   call set_jr(cjr, sigma, unit2)
-  ddsigdde = cvol + ciso + cjr
+  ddsigdde = cspatial + cjr
 
-  ! ============================================================================
-  ! VISCOUS CONTRIBUTION (optional)
-  ! ============================================================================
-  ! The viscous model operates on the material frame (PK2 + material tangent).
-  ! It modifies PK2 by adding viscous overstress and scales the isochoric
-  ! material tangent. We then push-forward the result to the spatial frame.
-  ! Note: viscosity applies to the continuum (matrix) part only. If a network
-  ! model is active, the network spatial contribution is added back afterwards.
-  if (n_visco > 0) then
-    vscprops = ZERO
-    do i = 1, min(n_visco, MAX_VISCO_BRANCHES)
-      vscprops(2*i-1) = props(ip)      ! tau
-      vscprops(2*i)   = props(ip+1)    ! theta
-      ip = ip + 2
-    end do
-
-    ! Offset: after det (1) + damage vars (2 if active)
-    sdv_offset_visco = 1
-    if (damage_type > 0) sdv_offset_visco = 3
-
-    ! visco_maxwell returns modified PK2 (pk2_visc) and material tangent (cmat_visc)
-    call visco_maxwell(pk2_visc, cmat_visc, &
-                       min(n_visco, MAX_VISCO_BRANCHES), pkvol, pkiso, &
-                       cmvol, cmiso, dtime, vscprops, statev, sdv_offset_visco)
-
-    ! Push-forward to get spatial quantities
-    call push2(sigma_visc, pk2_visc, dfgrd1, det)
-    call push4(cspatial_visc, cmat_visc, dfgrd1, det)
-
-    ! Jaumann rate correction with viscous Cauchy stress
-    call set_jr(cjr, sigma_visc, unit2)
-
-    ! Override elastic results with viscous-augmented versions
-    sigma    = sigma_visc
-    ddsigdde = cspatial_visc + cjr
-
-    ! Re-add the network (viscosity relaxes the matrix only; the network is
-    ! pristine — NOT relaxed). Use snet/cnet directly, NOT the blended sfic/cfic,
-    ! so the (1-phi)*matrix + phi*network blend is not double-counted (D2).
-    if (network_type > 0) then
-      call sig_iso(siso, snet, proje)
-      call set_iso(ciso, cnet, proje, siso, snet, unit2)
-      sigma    = sigma    + phi_net * siso
-      ddsigdde = ddsigdde + phi_net * ciso
-    end if
-  end if
-
-  ! ============================================================================
-  ! STRAIN ENERGY
-  ! ============================================================================
-  sse = ssev + sseiso + sseaniso
-
-  ! ============================================================================
-  ! VOIGT INDEXING (ABAQUS interface)
-  ! ============================================================================
   call indexx(stress, ddsdde, sigma, ddsigdde, ntens)
-
-  ! ============================================================================
-  ! STATE VARIABLES
-  ! ============================================================================
-  statev(1) = det
 
 end subroutine umat
 

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -8,6 +8,8 @@
   T6  network_check   - filament-network battery (smoke, RW quadrature, tangents)
   T7  recombination_check - visco x damage x network x AI-aniso recombination
   T8  robustness_check - no-NaN / graceful cutback on element inversion
+  T9  uel_tangent_check - UEL assembly tangent a = c + δ⊗σ vs FD of dP/dF
+  T10 uel_check        - generated UEL: traction oracle vs UMAT + AMATRX vs FD(RHS)
   B6  contractile_tangent_check - contractile consistent tangent (evolve-then-perturb)
 
 Exit code is nonzero if any 'good'/invariant check fails. Checks tagged as
@@ -28,6 +30,8 @@ import doc_consistency
 import network_check
 import recombination_check
 import robustness_check
+import uel_tangent_check
+import uel_check
 import contractile_tangent_check
 
 
@@ -41,6 +45,8 @@ def main():
                       ("T6 network", network_check),
                       ("T7 recombination", recombination_check),
                       ("T8 robustness", robustness_check),
+                      ("T9 uel-tangent", uel_tangent_check),
+                      ("T10 uel-element", uel_check),
                       ("B6 contractile-tangent", contractile_tangent_check)):
         print("=" * 70)
         print(name)

--- a/tests/uel_check.py
+++ b/tests/uel_check.py
@@ -1,0 +1,288 @@
+"""T10 - End-to-end checks of the generated UEL (element + material library).
+
+Two checks on a single U3D8 element (unit cube, affine nodal displacements
+u_a = (F - I) X_a, one increment from the virgin state):
+
+(a) Traction oracle — under affine loading the element's deformation gradient
+    is spatially constant and equals the prescribed F (F-bar inert: Fc = F),
+    so the internal force on the x+ face must equal the UMAT answer exactly:
+        f_pred = sigma_umat . (J F^{-T} e1)        (Nanson, reference area 1)
+    This ties the WHOLE element chain (kinematics, material call, B-matrix,
+    Gauss loop) to the independently verified UMAT stress.
+
+(b) Stiffness consistency — AMATRX vs central finite differences of RHS over
+    all 24 DOFs (state reset per call):  K_fd = -dRHS/du.
+    With fbar=off this must match tightly (consistent tangent through the
+    assembly — validates the geometric term a = c + δ⊗σ end to end).
+    With fbar=on it validates the F-bar tangent (Qmat) at an affine base
+    state, where de Souza Neto's q-matrix linearization is exact.
+
+Run:
+    .venv/bin/python tests/uel_check.py
+"""
+import sys
+import tempfile
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import harness as H  # noqa: E402
+import generate  # noqa: E402
+
+DRIVER = r"""
+program uel_fd_driver
+  implicit none
+  integer, parameter :: nnode = 8, ndofel = 24, mlvarx = 24, nrhs = 1
+  integer, parameter :: nprops = {NP}, nsdv = {NS}, nintp = {NINT}
+  integer, parameter :: nsvars = nintp*nsdv, njprop = 2
+  integer, parameter :: mcrd = 3, jtype = 3, jelem = 1
+  integer, parameter :: ndload = 0, mdload = 1, npredf = 1
+
+  double precision :: rhs(mlvarx,1), amatrx(ndofel,ndofel), svars(nsvars)
+  double precision :: energy(8), props(nprops), coords(mcrd,nnode)
+  double precision :: u(ndofel), du(mlvarx,1), v(ndofel), a(ndofel)
+  double precision :: time(2), dtime, params(1)
+  double precision :: adlmag(mdload,1), ddlmag(mdload,1)
+  double precision :: predef(2,npredf,nnode), pnewdt, period
+  integer :: jdltyp(mdload,1), lflags(4), jprops(njprop)
+
+  double precision :: Ftar(3,3), u0(ndofel), up(ndofel)
+  double precision :: rhs0(ndofel), rhsp(ndofel), rhsm(ndofel)
+  double precision :: k0(ndofel,ndofel), kfd(ndofel,ndofel), fface(3)
+  double precision :: h
+  integer :: i, j, n, k, face_nodes(4)
+  double precision, parameter :: zero = 0.0d0, one = 1.0d0
+
+{PROPS}
+  jprops(1) = nsdv
+  jprops(2) = nsdv
+  lflags = 0; lflags(1) = 1; lflags(2) = 1
+  dtime = {DTIME}d0
+  h = {H}d0
+  v = zero; a = zero; params = zero
+  adlmag = zero; ddlmag = zero; predef = zero; jdltyp = 0
+  period = zero
+  face_nodes = (/2, 3, 6, 7/)
+
+  ! Unit cube, element-local node ordering (z=0 face: 1-4, z=1 face: 5-8)
+  coords(:,1) = (/zero, zero, zero/)
+  coords(:,2) = (/one,  zero, zero/)
+  coords(:,3) = (/one,  one,  zero/)
+  coords(:,4) = (/zero, one,  zero/)
+  coords(:,5) = (/zero, zero, one /)
+  coords(:,6) = (/one,  zero, one /)
+  coords(:,7) = (/one,  one,  one /)
+  coords(:,8) = (/zero, one,  one /)
+
+{FBASE}
+
+  time = zero
+  call uexternaldb(0, 0, time, zero, 0, 0)
+
+  ! Affine nodal displacements for the base state
+  do n = 1, nnode
+    do k = 1, 3
+      u0(3*(n-1)+k) = sum(Ftar(k,:)*coords(:,n)) - coords(k,n)
+    end do
+  end do
+
+  ! --- base call: RHS, AMATRX, face force ---
+  call eval(u0, rhs0, k0)
+  fface = zero
+  do i = 1, 4
+    n = face_nodes(i)
+    do k = 1, 3
+      fface(k) = fface(k) - rhs0(3*(n-1)+k)
+    end do
+  end do
+
+  ! --- central FD of RHS over all DOFs (fresh state each call) ---
+  do j = 1, ndofel
+    up = u0; up(j) = u0(j) + h
+    call eval(up, rhsp, amatrx)
+    up = u0; up(j) = u0(j) - h
+    call eval(up, rhsm, amatrx)
+    kfd(:,j) = -(rhsp - rhsm) / (2.0d0*h)
+  end do
+
+  write(*,'(A)') 'FFACE'
+  write(*,'(3ES24.14)') fface
+  write(*,'(A)') 'RHS'
+  write(*,'(3ES24.14)') (rhs0(i), i=1,ndofel)
+  write(*,'(A)') 'AMATRX'
+  do i = 1, ndofel
+    write(*,'(4ES24.14)') (k0(i,j), j=1,ndofel)
+  end do
+  write(*,'(A)') 'KFD'
+  do i = 1, ndofel
+    write(*,'(4ES24.14)') (kfd(i,j), j=1,ndofel)
+  end do
+
+contains
+
+  !> One UEL call from the virgin state (single increment, kinc=1).
+  subroutine eval(uin, rhs_out, k_out)
+    double precision, intent(in)  :: uin(ndofel)
+    double precision, intent(out) :: rhs_out(ndofel), k_out(ndofel,ndofel)
+    svars = zero; time = zero; pnewdt = one
+    rhs = zero; amatrx = zero; energy = zero
+    u = uin
+    du(:,1) = uin   ! single increment from u=0
+    call uel(rhs, amatrx, svars, energy, ndofel, nrhs, nsvars, &
+             props, nprops, coords, mcrd, nnode, u, du, v, a, jtype, &
+             time, dtime, 1, 1, jelem, params, ndload, jdltyp, adlmag, &
+             predef, npredf, lflags, mlvarx, ddlmag, mdload, pnewdt, &
+             jprops, njprop, period)
+    rhs_out = rhs(:,1)
+    k_out = amatrx
+  end subroutine eval
+
+end program uel_fd_driver
+
+! Stub for ABAQUS-provided routine (standalone builds only)
+subroutine getoutdir(outdir, lenoutdir)
+  implicit none
+  character(len=256), intent(out) :: outdir
+  integer, intent(out) :: lenoutdir
+  outdir = '.'
+  lenoutdir = 1
+end subroutine getoutdir
+"""
+
+FFLAGS = ["-O2", "-ffree-form", "-ffpe-summary=none"]
+
+
+def _compile_and_run(tmp, driver_src, elem):
+    (tmp / "uel.f90").write_text(generate.uel_source(elem))
+    (tmp / "aba_param.inc").write_text((generate.SRC_DIR / "aba_param.inc").read_text())
+    drv = tmp / "uel_drv.f90"
+    drv.write_text(driver_src)
+    exe = tmp / "uel_drv"
+    r = subprocess.run(["gfortran", *FFLAGS, "-o", str(exe), str(tmp / "uel.f90"), str(drv)],
+                       capture_output=True, text=True, cwd=str(tmp))
+    if r.returncode != 0:
+        raise RuntimeError(f"compile failed:\n{r.stderr}")
+    return H.run_exe(exe)
+
+
+def _parse_vec(lines, start, n, per_line):
+    vals = []
+    rows = (n + per_line - 1) // per_line
+    for r in range(start, start + rows):
+        vals.extend(float(x) for x in lines[r].split())
+    return vals[:n]
+
+
+def _parse_mat(lines, start, n, per_line):
+    rows_per = (n + per_line - 1) // per_line
+    m = []
+    for i in range(n):
+        m.append(_parse_vec(lines, start + i * rows_per, n, per_line))
+    return m
+
+
+def uel_run(props, nstatev, F, elem, h=1e-6, dtime=1e-2, setup_files=None):
+    """Return (fface[3], rhs[24], K[24][24], Kfd[24][24]) for one increment to F."""
+    src = (DRIVER
+           .replace("{NP}", str(len(props)))
+           .replace("{NS}", str(nstatev))
+           .replace("{NINT}", str(elem["nint"]))
+           .replace("{DTIME}d0", H.fdbl(dtime))
+           .replace("{H}d0", H.fdbl(h))
+           .replace("{PROPS}", H.fmt_props(props))
+           .replace("{FBASE}", H.fmt_F(F, var="Ftar")))
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        for name, content in (setup_files or {}).items():
+            (tmp / name).write_text(content)
+        out = _compile_and_run(tmp, src, elem)
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    fface = _parse_vec(lines, lines.index("FFACE") + 1, 3, 3)
+    rhs = _parse_vec(lines, lines.index("RHS") + 1, 24, 3)
+    K = _parse_mat(lines, lines.index("AMATRX") + 1, 24, 4)
+    Kfd = _parse_mat(lines, lines.index("KFD") + 1, 24, 4)
+    return fface, rhs, K, Kfd
+
+
+# --- small 3x3 helpers (no numpy in the test env) ---------------------------
+
+def det3(F):
+    return (F[0][0]*(F[1][1]*F[2][2] - F[1][2]*F[2][1])
+            - F[0][1]*(F[1][0]*F[2][2] - F[1][2]*F[2][0])
+            + F[0][2]*(F[1][0]*F[2][1] - F[1][1]*F[2][0]))
+
+
+def inv3(F):
+    d = det3(F)
+    c = [[(F[(i+1) % 3][(j+1) % 3]*F[(i+2) % 3][(j+2) % 3]
+           - F[(i+1) % 3][(j+2) % 3]*F[(i+2) % 3][(j+1) % 3]) / d
+          for j in range(3)] for i in range(3)]
+    # c[i][j] = cofactor -> inverse = transpose of cofactor matrix / det
+    return [[c[j][i] for j in range(3)] for i in range(3)]
+
+
+def predicted_face_force(sigma_voigt, F):
+    """sigma . (J F^{-T} e1): Nanson area vector of the X=1 face (ref area 1)."""
+    s = sigma_voigt
+    sig = [[s[0], s[3], s[4]],
+           [s[3], s[1], s[5]],
+           [s[4], s[5], s[2]]]
+    J = det3(F)
+    Finv = inv3(F)
+    avec = [J * Finv[0][i] for i in range(3)]   # (F^{-T})_{i1} = Finv[0][i]
+    return [sum(sig[i][j] * avec[j] for j in range(3)) for i in range(3)]
+
+
+# --- checks ------------------------------------------------------------------
+
+ORACLE_TOL = 1e-8
+FD_TOL = 1e-6
+
+CASES = [
+    # (label, example name, fbar, states)
+    ("neo_hooke fbar=on", "neo_hooke", True,
+     [("general", H.F_general()), ("uniaxial λ=1.3", H.F_uniaxial(1.3))]),
+    ("neo_hooke fbar=off", "neo_hooke", False,
+     [("general", H.F_general())]),
+    ("humphrey_hgo fbar=on", "humphrey_hgo", True,
+     [("uniaxial λ=1.3 (fiber)", H.F_uniaxial(1.3))]),
+    ("neo_hooke_visco fbar=on", "neo_hooke_visco", True,
+     [("general", H.F_general())]),
+]
+
+
+def main(argv=None):
+    print(f"T10 UEL end-to-end (oracle tol {ORACLE_TOL:g}, FD-stiffness tol {FD_TOL:g})\n")
+    rc = 0
+    for label, name, fbar, states in CASES:
+        cfg = generate.EXAMPLES[name]
+        props, ns = H.props_from_cfg(cfg)
+        elem = dict(generate.DEFAULT_ELEMENT)
+        elem["fbar"] = fbar
+        for slabel, F in states:
+            try:
+                fface, rhs, K, Kfd = uel_run(props, ns, F, elem)
+                sigv, _, _ = H.stress_at(props, ns, F)
+                fpred = predicted_face_force(sigv, F)
+
+                fscale = max(abs(v) for v in fpred)
+                ferr = max(abs(a - b) for a, b in zip(fface, fpred)) / fscale
+
+                kscale = max(abs(v) for row in K for v in row)
+                kerr = max(abs(a - b) for ra, rb in zip(K, Kfd)
+                           for a, b in zip(ra, rb)) / kscale
+
+                ok = ferr < ORACLE_TOL and kerr < FD_TOL
+                flag = "PASS" if ok else "FAIL"
+                print(f"[{flag}] {label:24s} {slabel:22s} "
+                      f"oracle_rel={ferr:.2e}  K_fd_rel={kerr:.2e}")
+                if not ok:
+                    rc = 1
+            except Exception as e:
+                print(f"[FAIL] {label:24s} {slabel:22s} ERROR: {e}")
+                rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/uel_tangent_check.py
+++ b/tests/uel_tangent_check.py
@@ -1,0 +1,270 @@
+"""T9 - Numerical consistency check of the UEL assembly tangent (material_uel).
+
+The displacement-based UEL assembles Kuu = int G^T A G dv, which requires the
+push-forward of the FIRST elasticity tensor (no minor symmetry):
+
+    a_ijkl = (1/J) F_jJ F_lL dP_iJ/dF_kL = c_ijkl + delta_ik sigma_jl
+
+This is NOT the Jaumann-corrected modulus the UMAT path returns; getting this
+term wrong leaves the residual intact but degrades Newton convergence — exactly
+the latent bug the material_core/material_uel refactor fixed.
+
+Check: central finite differences of the first Piola-Kirchhoff stress
+P = J sigma F^{-T} under direct (unsymmetric) perturbation of single F entries,
+pushed forward at the base point, compared against material_uel's analytic
+tangent over all 81 components.
+
+Calibration (lessons.md): a verified-good model (Neo-Hooke) must pass at tight
+tolerance before any failure elsewhere is trusted. Fiber models are evaluated
+with the fiber engaged (I4>1) to stay off the I4=1 activation kink.
+
+Run:
+    .venv/bin/python tests/uel_tangent_check.py            # full battery
+    .venv/bin/python tests/uel_tangent_check.py neo_hooke  # one model, verbose
+"""
+import copy
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import harness as H  # noqa: E402
+import generate  # noqa: E402
+
+DRIVER = r"""
+program uel_tangent_driver
+  use mod_material, only: material_uel
+  use mod_tensor,   only: matinv3d
+  implicit none
+  integer, parameter :: nprops={NP}, nstatev={NS}
+  integer, parameter :: noel=1, npt=1
+
+  double precision :: statev(nstatev), props(nprops)
+  double precision :: time(2), predef(1), dpred(1)
+  double precision :: dtime, pnewdt, sse
+  double precision :: dfgrd1(3,3)
+  double precision :: F(3,3), Fp(3,3)
+  double precision :: sig0(3,3), a0(3,3,3,3)
+  double precision :: sigp(3,3), sigm(3,3), adum(3,3,3,3)
+  double precision :: Pp(3,3), Pm(3,3)
+  double precision :: Anum(3,3,3,3), a_num(3,3,3,3)
+  double precision :: j0, jp, jm, eps
+  integer :: i, jj, kk, ll, mJ, mL
+  double precision, parameter :: zero=0.d0, one=1.d0
+
+  eps = {EPS}d0
+  dtime = {DTIME}d0
+
+{PROPS}
+
+{FBASE}
+  F = dfgrd1
+
+  time = zero
+  call uexternaldb(0,0,time,zero,0,0)
+
+  ! --- base point: analytic UEL tangent ---
+  call eval(F, sig0, a0, j0)
+
+  ! --- central-difference dP/dF, one F entry at a time (unsymmetric) ---
+  Anum = zero
+  do kk = 1, 3
+    do ll = 1, 3
+      Fp = F
+      Fp(kk,ll) = F(kk,ll) + eps
+      call eval(Fp, sigp, adum, jp)
+      call piola(Fp, sigp, jp, Pp)
+      Fp = F
+      Fp(kk,ll) = F(kk,ll) - eps
+      call eval(Fp, sigm, adum, jm)
+      call piola(Fp, sigm, jm, Pm)
+      do i = 1, 3
+        do mJ = 1, 3
+          Anum(i,mJ,kk,ll) = (Pp(i,mJ) - Pm(i,mJ)) / (2.d0*eps)
+        end do
+      end do
+    end do
+  end do
+
+  ! --- push forward: a_ijkl = (1/J) F_jJ F_lL A_iJkL ---
+  a_num = zero
+  do i = 1, 3
+    do jj = 1, 3
+      do kk = 1, 3
+        do ll = 1, 3
+          do mJ = 1, 3
+            do mL = 1, 3
+              a_num(i,jj,kk,ll) = a_num(i,jj,kk,ll) &
+                + F(jj,mJ) * F(ll,mL) * Anum(i,mJ,kk,mL) / j0
+            end do
+          end do
+        end do
+      end do
+    end do
+  end do
+
+  ! --- emit both tensors (81 components each, fixed order) ---
+  write(*,'(A)') 'ANALYTIC'
+  write(*,'(3ES24.14)') ((((a0(i,jj,kk,ll), ll=1,3), kk=1,3), jj=1,3), i=1,3)
+  write(*,'(A)') 'NUMERICAL'
+  write(*,'(3ES24.14)') ((((a_num(i,jj,kk,ll), ll=1,3), kk=1,3), jj=1,3), i=1,3)
+
+contains
+
+  !> P = J sigma F^{-T}  (first Piola-Kirchhoff from Cauchy)
+  subroutine piola(Fin, sig, jdet, P)
+    double precision, intent(in)  :: Fin(3,3), sig(3,3), jdet
+    double precision, intent(out) :: P(3,3)
+    double precision :: Finv(3,3)
+    integer :: ii, jl, mm
+    call matinv3d(Fin, Finv)
+    P = zero
+    do ii = 1, 3
+      do jl = 1, 3
+        do mm = 1, 3
+          P(ii,jl) = P(ii,jl) + jdet * sig(ii,mm) * Finv(jl,mm)
+        end do
+      end do
+    end do
+  end subroutine piola
+
+  !> One material_uel call from a fresh reference state (algorithmic tangent).
+  subroutine eval(Fin, sig_out, a_out, det_out)
+    double precision, intent(in)  :: Fin(3,3)
+    double precision, intent(out) :: sig_out(3,3), a_out(3,3,3,3), det_out
+    double precision :: Floc(3,3)
+    statev = zero; time = zero; predef = zero; dpred = zero
+    pnewdt = one
+    Floc = Fin
+    call material_uel(sig_out, a_out, sse, statev, nstatev, props, nprops, &
+                      Floc, time, dtime, predef, dpred, pnewdt, &
+                      noel, npt, 1, 1)
+    det_out = statev(1)   ! material_core writes statev(1) = det(F)
+  end subroutine eval
+
+end program uel_tangent_driver
+
+! Stub for ABAQUS-provided routine (standalone builds only)
+subroutine getoutdir(outdir, lenoutdir)
+  implicit none
+  character(len=256), intent(out) :: outdir
+  integer, intent(out) :: lenoutdir
+  outdir = '.'
+  lenoutdir = 1
+end subroutine getoutdir
+"""
+
+
+def _parse_tensor(lines, start):
+    """81 values, 3 per line, 27 lines."""
+    vals = []
+    for r in range(start, start + 27):
+        vals.extend(float(x) for x in lines[r].split())
+    return vals
+
+
+def uel_tangent_error(props, nstatev, F, eps=1e-6, dtime=1e-2, setup_files=None):
+    """Compile+run the driver; return (analytic, numerical, max_abs_diff, scale)."""
+    src = (DRIVER
+           .replace("{NP}", str(len(props)))
+           .replace("{NS}", str(nstatev))
+           .replace("{EPS}d0", H.fdbl(eps))
+           .replace("{DTIME}d0", H.fdbl(dtime))
+           .replace("{PROPS}", H.fmt_props(props))
+           .replace("{FBASE}", H.fmt_F(F)))
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        for name, content in (setup_files or {}).items():
+            (tmp / name).write_text(content)
+        exe = H.compile_driver(tmp, src, "uel_tangent")
+        out = H.run_exe(exe)
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    ai = lines.index("ANALYTIC")
+    ni = lines.index("NUMERICAL")
+    analytic = _parse_tensor(lines, ai + 1)
+    numerical = _parse_tensor(lines, ni + 1)
+    maxdiff = max(abs(a - n) for a, n in zip(analytic, numerical))
+    scale = max(abs(a) for a in analytic)
+    return analytic, numerical, maxdiff, scale
+
+
+STATES = [
+    ("uniaxial λ=1.2", H.F_uniaxial(1.2)),
+    ("biaxial λ=1.2", H.F_biaxial(1.2)),
+    ("simple shear γ=0.2", H.F_simple_shear(0.2)),
+    ("general", H.F_general()),
+]
+
+# Fiber models gate on the I4=1 tension kink — evaluate with the fiber engaged
+# (see tangent_check.py and lessons.md).
+FIBER_STATES = [
+    ("uniaxial λ=1.3 (fiber)", H.F_uniaxial(1.3)),
+    ("biaxial λ=1.2", H.F_biaxial(1.2)),
+    ("general (stretch+shear)", H.F_general()),
+]
+
+
+def _cfg(name, **over):
+    c = copy.deepcopy(generate.EXAMPLES[name])
+    c.update(over)
+    return c
+
+
+_hgo_k0 = _cfg("humphrey_hgo", aniso_params=[100.0, 10.0, 0.0, 1.0, 0.0, 0.0])
+_dmg_active = _cfg("neo_hooke_damage", damage_params=[5.0, 1.0])
+
+MODELS = [
+    ("neo_hooke", generate.EXAMPLES["neo_hooke"], "good", STATES),
+    ("mooney_rivlin", generate.EXAMPLES["mooney_rivlin"], "good", STATES),
+    ("ogden_3term", generate.EXAMPLES["ogden_3term"], "good", STATES),
+    ("neo_hooke_visco", generate.EXAMPLES["neo_hooke_visco"], "good", STATES),
+    ("hgo_kappa0 (control)", _hgo_k0, "good", FIBER_STATES),
+    ("humphrey_hgo κ=0.226", generate.EXAMPLES["humphrey_hgo"], "good", FIBER_STATES),
+    ("neo_hooke_damage (inactive)", generate.EXAMPLES["neo_hooke_damage"], "good", STATES),
+    ("damage_active", _dmg_active, "good", STATES),
+]
+
+REL_TOL = 1e-4
+
+
+def main(argv=None):
+    argv = argv or [sys.argv[0]]
+    if len(argv) > 1:
+        name = argv[1]
+        props, ns = H.props_for(name)
+        print(f"== {name}  (nprops={len(props)}, nstatev={ns}) ==")
+        for label, F in STATES:
+            _, _, md, sc = uel_tangent_error(props, ns, F)
+            rel = md / sc if sc > 0 else md
+            verdict = "PASS" if rel < REL_TOL else "FAIL"
+            print(f"  {label:22s} maxdiff={md:.3e} scale={sc:.3e} rel={rel:.3e}  {verdict}")
+        return 0
+
+    print(f"T9 UEL-tangent battery: a_ijkl = c + δ⊗σ vs FD of dP/dF (rel tol {REL_TOL:g})\n")
+    rc = 0
+    for name, cfg, tag, states in MODELS:
+        props, ns = H.props_from_cfg(cfg)
+        worst = 0.0
+        details = []
+        for label, F in states:
+            try:
+                _, _, md, sc = uel_tangent_error(props, ns, F)
+                rel = md / sc if sc > 0 else md
+            except Exception as e:
+                details.append(f"{label}: ERROR {e}")
+                rel = float("inf")
+            worst = max(worst, rel)
+            details.append(f"{label}: rel={rel:.2e}")
+        ok = worst < REL_TOL
+        flag = "PASS" if ok else "FAIL"
+        note = "" if (ok == (tag == "good")) else "  <-- unexpected!"
+        print(f"[{flag}] {name:20s} worst_rel={worst:.2e}  ({tag}){note}")
+        for d in details:
+            print(f"        {d}")
+        if tag == "good" and not ok:
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Makes the library's element-level story symmetric with its material story: any model config can now be emitted as a **user element** (`uel.f90`) alongside the UMAT, driven through one shared constitutive core.

- **Shared core** — `umat_builder.f90` is restructured into module `mod_material`: `material_core` (PROPS dispatch → kinematics → constitutive → visco; returns full Cauchy stress + bare spatial tangent) with two thin wrappers: `umat` (+ Jaumann + Voigt — regression-identical) and `material_uel` (+ geometric term).
- **Element layer** — U3D8 8-node brick with the F-bar method, ported from the standalone UEL-ABAQUS repo to free-form modules in `src/element/` (mechanical-only; dead donor-code paths removed, two latent bugs fixed).
- **Generator** — `umat-generate --uel` (or an `"element"` config block) emits `uel.f90`, a standalone single-element driver `test_uel.f90`, and `abaqus/uel_cube.inp` + `run_uel.sh` with the `*User Element` card auto-filled (`Properties`, `Variables = nint×NSTATEV`, `Unsymm`, dummy mesh + UVARM).

## The correctness fix

A displacement UEL assembling `Kuu = ∫ Gᵀ A G dv` needs `a_ijkl = c_ijkl + δ_ik σ_jl` (push-forward of ∂P/∂F, unsymmetric), **not** the Jaumann-corrected UMAT modulus. The old UEL-ABAQUS coupling fed it the UMAT modulus — correct residual, degraded Newton. The new `set_geometric` in `mod_continuum.f90` plus the wrapper split fixes this at the source.

Behavior note: with visco+network both active, the Jaumann term now uses the **total** Cauchy stress (the network contribution was previously omitted from `cjr`).

## Verification

| Check | Result |
|---|---|
| T1–T8, B6 (existing suite) | green — `umat` path regression-clean |
| T9: UEL tangent vs central FD of ∂P/∂F | ~1e-10 across 8 model configs × 3–4 states |
| T10: element traction oracle vs UMAT | ~1e-14 (affine single element) |
| T10: AMATRX vs FD of RHS (24 DOFs, state reset per call) | ~5e-10, F-bar on **and** off |

Run with `make verify`. Not covered: an actual ABAQUS submission of `uel_cube.inp` (no license on the dev machine) — first real run may surface deck-syntax nits; the element numerics are covered by T10.

## Notes for review

- Builds on the correctness-audit fixes from #5 (rebased onto master after #5 was squash-merged).
- `tests/uel_check.py` measures F-bar tangent consistency at **affine** base states, where the q-matrix linearization is exact; non-affine states would show the standard approximate-F-bar-tangent error (costs Newton iterations, not correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
