### PR TITLE
Reflect repo rename (abaqus-material-lab) in docs and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# UMAT-ABAQUS Library
+# ABAQUS Material Lab
 
-A composable UMAT framework for finite-strain constitutive modelling of soft biological tissues and filamentous networks in ABAQUS.
+A composable framework for finite-strain constitutive modelling of soft biological tissues and filamentous networks in ABAQUS. One constitutive core emits both `UMAT` material subroutines (for built-in elements) and `UEL` user elements.
 
 ## What this repository does
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "umat-abaqus-library"
+name = "abaqus-material-lab"
 version = "0.1.0"
-description = "Generator for self-contained ABAQUS UMAT material law directories"
+description = "Generator for self-contained ABAQUS material laws — UMAT subroutines and UEL user elements"
 requires-python = ">=3.8"
 license = "MIT"
 dependencies = ["numpy"]


### PR DESCRIPTION
Repo renamed `UMAT-ABAQUS_library` → `abaqus-material-lab` (GitHub-side, done; redirects in place). This updates the two tracked self-references:

- README H1 title + tagline (now notes the single core emits both UMAT and UEL).
- `pyproject.toml` package `name` and `description`.

The `umat-generate` console script name is intentionally **unchanged** (renaming it would ripple through all docs and break existing workflows). The `.egg-info/` metadata is a gitignored build artifact and regenerates on next install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)